### PR TITLE
feat(github-status): allow sending multiple tokens to be used

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -30,9 +30,24 @@ module Travis
 
           def process
             info("Update commit status on #{url} to #{state}")
-            authenticated do
+
+            tokens = params.fetch(:tokens) { { '<legacy format>' => params[:token] } }
+
+            tokens.each do |username, token|
+              if process_with_token(token)
+                return
+              else
+                error "#{username}'s GitHub token couldn't be used to update PR status on #{GH.api_host + url}."
+              end
+            end
+          end
+
+          def process_with_token(token)
+            authenticated(token) do
               GH.post(url, :state => state, :description => description, :target_url => target_url, context: 'continuous-integration/travis-ci')
             end
+          rescue GH::Error(:response_status => 401)
+            nil
           rescue GH::Error => e
             message = "Could not update the PR status on #{GH.api_host + url} (#{e.message})."
             error message
@@ -60,12 +75,12 @@ module Travis
             DESCRIPTIONS[state]
           end
 
-          def authenticated(&block)
-            GH.with(http_options, &block)
+          def authenticated(token, &block)
+            GH.with(http_options(token), &block)
           end
 
-          def http_options
-            super.merge(token: params[:token], headers: headers)
+          def http_options(token)
+            super().merge(token: token, headers: headers)
           end
 
           def headers


### PR DESCRIPTION
This is a port of the changes in travis-ci/travis-core#332 relevant to travis-tasks after the dependency on travis-core was removed.

It should be completely backwards compatible.
