### PR TITLE
Add XMPP Addon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'metriks-librato_metrics'
 gem 'hashr'
 gem 'multi_json'
 gem 'pusher'
+gem 'xmpp4r',         '~> 0.5.0'
 
 group :test do
   gem 'rspec',        '~> 2.14.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.3)
     ffi (1.9.3-java)
     foreman (0.71.0)
       dotenv (~> 0.11.1)
@@ -85,6 +86,7 @@ GEM
     hashie (3.0.0)
     hashr (0.0.22)
     hike (1.2.3)
+    hitimes (1.2.1)
     hitimes (1.2.1-java)
     httpclient (2.3.4.1)
     i18n (0.6.9)
@@ -179,6 +181,7 @@ GEM
     webmock (1.8.11)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
+    xmpp4r (0.5.6)
 
 PLATFORMS
   java
@@ -204,3 +207,4 @@ DEPENDENCIES
   sidekiq (~> 2.17.0)
   travis-support!
   webmock (~> 1.8.0)
+  xmpp4r (~> 0.5.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-tasks:   bundle exec sidekiq -c 25 -r ./lib/travis/tasks.rb -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q pusher -q sqwiggle -q webhook -q slack
+tasks:   bundle exec sidekiq -c 25 -r ./lib/travis/tasks.rb -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q pusher -q sqwiggle -q webhook -q slack -q xmpp

--- a/lib/travis/addons.rb
+++ b/lib/travis/addons.rb
@@ -11,5 +11,6 @@ module Travis
     require 'travis/addons/util'
     require 'travis/addons/webhook'
     require 'travis/addons/slack'
+    require 'travis/addons/xmpp'
   end
 end

--- a/lib/travis/addons/README.markdown
+++ b/lib/travis/addons/README.markdown
@@ -12,5 +12,6 @@ The Addons are event handlers that accepts events such as "build finished" and f
 - Sqwiggle
 - States cache: Caches the state of each branch in Memcached for status images.
 - Webhook
+- XMPP
 
 To add a new notification service, an event handler and a task is needed. The event handler is run by [`travis-hub`](https://github.com/travis-ci/travis-hub) and has access to the database. This should check whether the event should be forwarded at all, and pull out any necessary configuration values. It should then asynchronously run the corresponding Task. The Task is run by [`travis-tasks`](https://github.com/travis-ci/travis-tasks) via Sidekiq and should do the actual API calls needed. The event handler should finish very quickly, while the task is allowed to take longer. 

--- a/lib/travis/addons/xmpp.rb
+++ b/lib/travis/addons/xmpp.rb
@@ -1,0 +1,8 @@
+module Travis
+  module Addons
+    module Xmpp
+      require 'travis/addons/xmpp/client'
+      require 'travis/addons/xmpp/task'
+    end
+  end
+end

--- a/lib/travis/addons/xmpp/client.rb
+++ b/lib/travis/addons/xmpp/client.rb
@@ -1,0 +1,69 @@
+module Travis
+  module Addons
+    module Xmpp
+      class Client
+        require 'xmpp4r/client'
+        require 'xmpp4r/muc/helper/simplemucclient'
+
+        include Jabber
+
+        attr_accessor :jid, :password, :client
+
+        def initialize(jid, password)
+          @jid           = ::Jabber::JID.new(jid)
+          @password      = password
+          @client        = ::Jabber::Client.new(jid)
+        end
+
+        def connect
+          client.connect
+          client.auth(password)
+        end
+
+        def join_room(room_jid, passord = nil)
+          room_client.join(::Jabber::JID.new(room_jid), password)
+        end
+
+        # Send to Multi User Chatroom
+        def send_room(message)
+          room_client.say(message)
+        rescue => e
+          Travis.logger.error("Error sending message to XMPP room #{room_client.jid}: #{e.message}")
+        end
+
+        def quit_room
+          room_client.exit
+        end
+
+        def send_user(recipient_jid, message)
+          client.send(xmpp_message(recipient_jid, message))
+        rescue => e
+          Travis.logger.error("Error sending message to XMPP user #{recipient_jid}: #{e.message}")
+        end
+
+        def run(&block)
+          connect
+          yield(self) if block_given?
+        ensure
+          close
+        end
+
+        def close
+          client.close
+        end
+
+        private
+
+        def room_client
+          @room_client ||= ::Jabber::MUC::SimpleMUCClient.new(client)
+        end
+
+        def xmpp_message(recipient_jid, message)
+          jabber_message = ::Jabber::Message.new(recipient_jid, message)
+          jabber_message.set_type(:headline)
+          jabber_message
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/addons/xmpp/task.rb
+++ b/lib/travis/addons/xmpp/task.rb
@@ -1,0 +1,68 @@
+module Travis
+  module Addons
+    module Xmpp
+      class Task < Travis::Task
+        DEFAULT_TEMPLATE = [
+          "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): the build has %{result}",
+          "Change view: %{compare_url}",
+          "Build details: %{build_url}"
+        ]
+
+        def messages
+          @messages ||= template.map { |line| Util::Template.new(line, payload).interpolate }
+        end
+
+        private
+
+        def process
+          Client.new(jid, password).run do |client|
+            process_rooms(client)
+            process_users(client)
+          end
+        end
+
+        def process_rooms(client)
+          room_targets.each do |room_data|
+            client.join_room(room_data[:jid], room_data[:password])
+            messages.each { |message| client.send_room(message) }
+            client.quit_room
+          end
+        end
+
+        def process_users(client)
+          user_targets.each do |user_jid|
+            messages.each { |message| client.send_user(user_jid, message) }
+          end
+        end
+
+        def template
+          Array(config[:template] || DEFAULT_TEMPLATE)
+        end
+
+        def jid
+          config[:jid]
+        end
+
+        def password
+          config[:password]
+        end
+
+        def config
+          build[:config][:notifications][:xmpp] rescue {}
+        end
+
+        def room_targets
+          targets[:rooms] || []
+        end
+
+        def user_targets
+          targets[:users] || []
+        end
+
+        def targets
+          params[:targets]
+        end
+      end
+    end
+  end
+end

--- a/spec/addons/xmpp/client_spec.rb
+++ b/spec/addons/xmpp/client_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Travis::Addons::Xmpp::Client do
+  Jabber.debug = true
+
+  let(:subject)       { Travis::Addons::Xmpp::Client }
+  let(:jid)           { 'travis_bot' }
+  let(:room_jid)      { 'travis' }
+  let(:message)       { 'hello' }
+  let(:xmpp_client)   { stub(auth: true, connect: true, close: true, send: true) }
+  let(:muc_client)    { stub(join: true, say: true, active?: false) }
+  let(:password)      { 'secret' }
+  let(:recipient_jid) { 'user_jid' }
+
+  before do
+    ::Jabber::Client.stubs(:new).returns xmpp_client
+  end
+
+  describe '#connect' do
+    it 'authenticates with the password' do
+      xmpp_client.expects(:auth).with(password)
+      subject.new(jid, password).connect
+    end
+  end
+
+  describe '#send_user' do
+    it 'sends the message' do
+      xmpp_client.expects(:send)
+      subject.new(jid, password).send_user(recipient_jid, message)
+    end
+  end
+
+  describe '#run' do
+    it 'ensures the close of client' do
+      xmpp_client.expects(:close)
+      subject.new(jid, password).run { raise 'An unexpected error' } rescue nil
+    end
+
+    it 'connects before running the code' do
+      xmpp_client.expects(:connect)
+      subject.new(jid, password).run { 'Some code' }
+    end
+  end
+end

--- a/spec/addons/xmpp/task_spec.rb
+++ b/spec/addons/xmpp/task_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Travis::Addons::Xmpp::Task do
+  include Travis::Testing::Stubs
+
+  let(:subject) { Travis::Addons::Xmpp::Task }
+  let(:payload) { Marshal.load(Marshal.dump(TASK_PAYLOAD)) }
+  let(:client)  { stub(run: true, send_channel: true, send: true) }
+  let(:rooms)   do
+    [
+      { jid: 'secretroom@example.com', password: 'password' },
+      { jid: 'mainhall@example.com' }
+    ]
+  end
+
+  let(:targets) do
+    {
+      rooms: rooms,
+      users: ['one@example.com', 'two@example.com']
+    }
+  end
+
+  describe '#process' do
+    before do
+      payload['build']['config']['notifications'] = { xmpp: { jid: 'travis', password: 'travis_password' } }
+    end
+
+    it 'instanciates a Client' do
+      Travis::Addons::Xmpp::Client.expects(:new)
+        .with('travis', 'travis_password').returns(client)
+      subject.new(payload, targets: targets).send(:process)
+    end
+  end
+end


### PR DESCRIPTION
Follow up of travis-ci/travis-core#357

The XMPP Addon can join to multiple rooms or send to multiple user. It
needs credentials (jid and password) to connect to a XMPP server.

The configuration format looks like : 

``` yaml
notifications:
  xmpp:
    jid: 'awesome_travis_user@example.com'
    password: 'password'
    rooms:
      - jid: mainhall@example.com/anAwesomePseudo
      - jid: secretroom@example.com/TravisBot
        password: 'password'
    users:
      - one@example.com
      - two@example.com
    template:
      - "%{repository} (%{commit}) : %{message} %{foo} "
      - "Build details: %{build_url}"
```
