### PR TITLE
Support HipChat v2 Notifications

### DIFF
--- a/lib/travis/addons/hipchat/http_helper.rb
+++ b/lib/travis/addons/hipchat/http_helper.rb
@@ -45,7 +45,7 @@ module Travis
           when 'v1'
             { room_id: room_id, message: info[:line], color: info[:color], from: 'Travis CI', message_format: info[:message_format] }
           when 'v2'
-            { message: info[:line], color: info[:color], message_format: info[:message_format] }.to_json
+            { message: info[:line], color: info[:color], message_format: info[:message_format], notify: info[:notify] }.to_json
           end
         end
 

--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -41,7 +41,7 @@ module Travis
           def send_message(helper, message)
             message.each do |line|
               response = http.post(helper.url) do |r|
-                r.body = helper.body(line: line, color: color, message_format: message_format)
+                r.body = helper.body(line: line, color: color, message_format: message_format, notify: notify)
                 helper.add_content_type!(r.headers)
               end
 
@@ -54,6 +54,10 @@ module Travis
           def template
             template = config[:template] rescue nil
             Array(template || DEFAULT_TEMPLATE)
+          end
+
+          def notify
+            (config[:notify] rescue nil) || false
           end
 
           def color


### PR DESCRIPTION
@BanzaiMan Rebases PR #17. From original PR:

> allows a notify: true option to allow notifications in hipchat v2 api
> 
> api reference: https://www.hipchat.com/docs/apiv2/method/send_room_notification
> issue: travis-ci/travis-ci#2814
