### PR TITLE
Update backports to 3.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     aws-sdk (1.43.3)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    backports (3.6.0)
+    backports (3.6.4)
     builder (3.0.4)
     celluloid (0.15.2)
       timers (~> 1.1.0)


### PR DESCRIPTION
3.6.0 is broken on ruby ~> 2.1.3

See https://github.com/marcandre/backports/issues/86
