### PR TITLE
Add information about PRs in chat notifications.

### DIFF
--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -2,6 +2,10 @@ module Travis
   module Addons
     module Slack
       class Task < Travis::Task
+
+        BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}"
+        PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request}> by %{author} %{result} in %{duration}"
+
         def process
           targets.each do |target|
             if illegal_format?(target)
@@ -56,7 +60,7 @@ module Travis
         end
 
         def message_text
-          lines = Array(template_from_config || "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}")
+          lines = Array(template_from_config || default_template)
           lines.map {|line| Util::Template.new(line, payload).interpolate}.join("\n")
         end
 
@@ -77,6 +81,14 @@ module Travis
 
         def slack_config
           build[:config].try(:[], :notifications).try(:[], :slack) || {}
+        end
+
+        def default_template
+          if pull_request?
+            PULL_REQUEST_MESSAGE_TEMPLATE
+          else
+            BRANCH_BUILD_MESSAGE_TEMPLATE
+          end
         end
       end
     end

--- a/lib/travis/addons/util/template.rb
+++ b/lib/travis/addons/util/template.rb
@@ -22,6 +22,7 @@ module Travis
             repository_name:       data[:repository][:name],
             build_number:          data[:build][:number].to_s,
             build_id:              data[:build][:id].to_s,
+            pull_request:          data[:build][:pull_request],
             branch:                data[:commit][:branch],
             commit:                data[:commit][:sha][0..6],
             author:                data[:commit][:author_name],
@@ -30,7 +31,8 @@ module Travis
             duration:              seconds_to_duration(data[:build][:duration]),
             message:               message,
             compare_url:           compare_url,
-            build_url:             build_url
+            build_url:             build_url,
+            pull_request_url:      pull_request_url
           }
         end
 
@@ -46,6 +48,19 @@ module Travis
         def build_url
           url = "http://#{Travis.config.host}/#{data[:repository][:slug]}/builds/#{data[:build][:id]}"
           short_urls? ? shorten_url(url) : url
+        end
+
+        def pull_request_url
+          if pr = data[:build][:pull_request]
+            uri = URI.parse(data[:commit][:compare_url])
+
+            parts = uri.path.split("/", 4)[0..2]
+            parts << "pull/#{pr}"
+
+            uri.path = parts.join("/")
+
+            short_urls? ? shorten_url(uri.to_s) : uri.to_s
+          end
         end
 
         private

--- a/spec/addons/slack/task_spec.rb
+++ b/spec/addons/slack/task_spec.rb
@@ -93,6 +93,28 @@ describe Travis::Addons::Slack::Task do
     http.verify_stubbed_calls
   end
 
+  it "sends information about pull requests" do
+    targets = ['team-1:token-1#channel1']
+    payload['build']['pull_request'] = '1'
+
+    expected_text = 'Build <http://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master in PR <https://github.com/svenfuchs/minimal/pull/1|#1> by Sven Fuchs passed in 1 min 0 sec'
+
+    message = {
+      icon_url: "https://travis-ci.org/images/travis-mascot-150.png",
+      channel: '#channel1',
+      attachments: [{
+        fallback: expected_text,
+        text: expected_text,
+        color: 'good'
+      }.stringify_keys]
+    }.stringify_keys
+
+    expect_slack('team-1', 'token-1', message)
+
+    run(targets)
+    http.verify_stubbed_calls
+  end
+
 
   def expect_slack(account, token, body)
     host = "#{account}.slack.com"

--- a/spec/addons/util/template_spec.rb
+++ b/spec/addons/util/template_spec.rb
@@ -17,6 +17,7 @@ describe Travis::Addons::Util::Template do
     compare_url
     build_url
     result
+    pull_request
   )
   TEMPLATE  = VAR_NAMES.map { |name| "#{name}=%{#{name}}" }.join(' ')
 
@@ -60,6 +61,24 @@ describe Travis::Addons::Util::Template do
 
     it 'replaces the message' do
       result.should =~ /message=The build passed./
+    end
+
+    it 'replaces the pull request' do
+      result.should =~ /pull_request=false/
+    end
+  end
+
+  describe 'pull_request_url' do
+    it 'returns nil when there is no pull request' do
+      template.pull_request_url.should be_nil
+    end
+
+    it 'returns the pull request url based on the comparison url' do
+      data = Marshal.load(Marshal.dump(TASK_PAYLOAD.merge({"build" => {"pull_request" => "1"}})))
+      template = Travis::Addons::Util::Template.new(TEMPLATE.dup, data)
+
+      expectation = "https://github.com/svenfuchs/minimal/pull/1"
+      template.pull_request_url.should == expectation
     end
   end
 end


### PR DESCRIPTION
A different message helps to visualize when you're building `master` and when you're building a pull request where `master` is the target branch.

I only modified Slack because it's the only chat client that I use, but I guess it should be easily portable to others.
