### PR TITLE
Use pull_request_number to extract the id of the Pull Request on GitHub.

### DIFF
--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -4,7 +4,7 @@ module Travis
       class Task < Travis::Task
 
         BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}"
-        PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request}> by %{author} %{result} in %{duration}"
+        PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request_number}> by %{author} %{result} in %{duration}"
 
         def process
           targets.each do |target|

--- a/lib/travis/addons/util/template.rb
+++ b/lib/travis/addons/util/template.rb
@@ -23,6 +23,7 @@ module Travis
             build_number:          data[:build][:number].to_s,
             build_id:              data[:build][:id].to_s,
             pull_request:          data[:build][:pull_request],
+            pull_request_number:   data[:build][:pull_request_number],
             branch:                data[:commit][:branch],
             commit:                data[:commit][:sha][0..6],
             author:                data[:commit][:author_name],
@@ -51,11 +52,11 @@ module Travis
         end
 
         def pull_request_url
-          if pr = data[:build][:pull_request]
+          if data[:build][:pull_request]
             uri = URI.parse(data[:commit][:compare_url])
 
             parts = uri.path.split("/", 4)[0..2]
-            parts << "pull/#{pr}"
+            parts << "pull/#{data[:build][:pull_request_number]}"
 
             uri.path = parts.join("/")
 

--- a/spec/addons/slack/task_spec.rb
+++ b/spec/addons/slack/task_spec.rb
@@ -51,7 +51,7 @@ describe Travis::Addons::Slack::Task do
     run(targets)
     http.verify_stubbed_calls
   end
-  
+
   it "allows specifying a custom template" do
     targets = ['team-1:token-1']
     payload['build']['config']['notifications'] = { slack: { template: 'Custom: %{author}'}} 
@@ -95,7 +95,8 @@ describe Travis::Addons::Slack::Task do
 
   it "sends information about pull requests" do
     targets = ['team-1:token-1#channel1']
-    payload['build']['pull_request'] = '1'
+    payload['build']['pull_request'] = true
+    payload['build']['pull_request_number'] = '1'
 
     expected_text = 'Build <http://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master in PR <https://github.com/svenfuchs/minimal/pull/1|#1> by Sven Fuchs passed in 1 min 0 sec'
 


### PR DESCRIPTION
This fixes an issue in the Slack notifications.
