### PR TITLE
add pushover notification support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-tasks: bundle exec sidekiq -c 25 -r ./lib/travis/tasks.rb -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q pusher -q sqwiggle -q webhook -q slack
+tasks: bundle exec sidekiq -c 25 -r ./lib/travis/tasks.rb -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q pusher -q sqwiggle -q webhook -q slack -q pushover

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Travis Task is a [Sidekiq](http://sidekiq.org/) based background processor whose
 
 These notifications are all queued up by state changes which are processed by [Travis Hub](https://github.com/travis-ci/travis-hub) and [Travis Gatekeeper](https://github.com/travis-ci/travis-gatekeeper).
 
-And, to make Travis Tasks even more special, there is no database connection required! Travis Tasks is all about talking to 3rd party services, if it be [Pusher](http://pusher.com), [Mandrill](https://mandrillapp.com), [Campfire](http://campfirenow.com/), or [Slack](http://slack.com/).
+And, to make Travis Tasks even more special, there is no database connection required! Travis Tasks is all about talking to 3rd party services, if it be [Pusher](http://pusher.com), [Mandrill](https://mandrillapp.com), [Campfire](http://campfirenow.com/), [Slack](http://slack.com/), or [Pushover](https://pushover.net/).
 
 You can find the full list of addon services Travis natively talks to within [Travis Core](https://github.com/travis-ci/travis-core/tree/master/lib/travis/addons).
 

--- a/lib/travis/addons.rb
+++ b/lib/travis/addons.rb
@@ -11,5 +11,6 @@ module Travis
     require 'travis/addons/util'
     require 'travis/addons/webhook'
     require 'travis/addons/slack'
+    require 'travis/addons/pushover'
   end
 end

--- a/lib/travis/addons/README.markdown
+++ b/lib/travis/addons/README.markdown
@@ -12,5 +12,6 @@ The Addons are event handlers that accepts events such as "build finished" and f
 - Sqwiggle
 - States cache: Caches the state of each branch in Memcached for status images.
 - Webhook
+- Pushover
 
 To add a new notification service, an event handler and a task is needed. The event handler is run by [`travis-hub`](https://github.com/travis-ci/travis-hub) and has access to the database. This should check whether the event should be forwarded at all, and pull out any necessary configuration values. It should then asynchronously run the corresponding Task. The Task is run by [`travis-tasks`](https://github.com/travis-ci/travis-tasks) via Sidekiq and should do the actual API calls needed. The event handler should finish very quickly, while the task is allowed to take longer. 

--- a/lib/travis/addons/pushover.rb
+++ b/lib/travis/addons/pushover.rb
@@ -1,0 +1,7 @@
+module Travis
+  module Addons
+    module Pushover
+      require 'travis/addons/pushover/task'
+    end
+  end
+end

--- a/lib/travis/addons/pushover/task.rb
+++ b/lib/travis/addons/pushover/task.rb
@@ -1,0 +1,61 @@
+require 'multi_json'
+
+module Travis
+  module Addons
+    module Pushover
+
+      # Publishes a build notification to Pushover as defined in the
+      # configuration (`.travis.yml`).
+      #
+      # Pushover API key and user key(s) are encrypted using the repository's ssl key.
+      class Task < Travis::Task
+        DEFAULT_TEMPLATE = "[travis-ci] %{repository}#%{build_number} (%{branch}): the build has %{result}. Details: %{build_url}"
+
+        def message
+          @message ||= Util::Template.new(template, payload).interpolate
+        end
+        
+        def users
+          params[:users]
+        end
+
+        def api_key
+          params[:api_key]
+        end
+        
+        private
+
+          def process
+            token = api_key        
+            users.each { |user| send_message(user, message, token) }
+          end
+
+          def send_message(user, message, token)
+            # this is roughly per https://pushover.net/faq#library-ruby
+            msg_h = {:token => token, :user => user, :message => message}
+            if is_failure
+              msg_h[:sound] = 'falling'
+            end
+            http.post("https://api.pushover.net/1/messages.json") do |r|
+              r.body = msg_h
+            end
+          rescue => e
+            Travis.logger.info("Error connecting to Pushover service for token #{token} user #{user}: #{e.message}")
+          end
+
+          def template
+            template = config[:template] rescue nil
+            template || DEFAULT_TEMPLATE
+          end
+
+          def is_failure
+            ['failed', 'errored', 'canceled'].include? build[:state]
+          end
+
+          def config
+            build[:config][:notifications][:pushover] rescue {}
+          end
+      end
+    end
+  end
+end

--- a/spec/addons/pushover/task_spec.rb
+++ b/spec/addons/pushover/task_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Travis::Addons::Pushover::Task do
+  include Travis::Testing::Stubs
+
+  let(:subject) { Travis::Addons::Pushover::Task }
+  let(:http)    { Faraday::Adapter::Test::Stubs.new }
+  let(:client)  { Faraday.new { |f| f.request :url_encoded; f.adapter :test, http } }
+  let(:payload) { Marshal.load(Marshal.dump(TASK_PAYLOAD)) }
+
+  before do
+    subject.any_instance.stubs(:http).returns(client)
+  end
+
+  def run(users, api_key)
+    subject.new(payload, users: users, api_key: api_key).run
+  end
+
+  it "sends pushover notifications to the given targets" do
+    message = '[travis-ci] svenfuchs/minimal#2 (master): the build has passed. Details: http://travis-ci.org/svenfuchs/minimal/builds/1'
+    api_key = 'foobarbaz'
+    users = ['userkeyone', 'userkeytwo']
+    
+    expect_pushover('foobarbaz', 'userkeyone', message)
+    expect_pushover('foobarbaz', 'userkeytwo', message)
+    
+    run(users, api_key)
+    http.verify_stubbed_calls
+  end
+
+  it 'using a custom template' do
+    template = '%{repository} %{commit}'
+    message = 'svenfuchs/minimal 62aae5f'
+    payload['build']['config']['notifications'] = { pushover: { template: template} }
+    api_key = 'foobarbaz'
+    users = ['userkeythree', 'userkeyfour']
+    
+    expect_pushover('foobarbaz', 'userkeythree', message)
+    expect_pushover('foobarbaz', 'userkeyfour', message)
+
+    run(users, api_key)
+    http.verify_stubbed_calls
+  end
+
+  def hash_to_query(hash)
+    return URI.encode(hash.map{|k,v| "#{k}=#{v}"}.join("&"))
+  end
+  
+  def expect_pushover(token, user, message)
+    host = "api.pushover.net"
+    path = "/1/messages.json"
+    expected_hash = {:message => message, :user => user, :token => token}
+    
+    http.post(path) do |env|
+      env[:url].host.should == host
+      env[:url].scheme.should == "https"
+      env[:url].path.should == path
+      Rack::Utils.parse_nested_query(env[:body]).should == expected_hash.stringify_keys
+    end
+  end
+end
+


### PR DESCRIPTION
This adds support for notifications via [Pushover](https://pushover.net/), a push messaging service with clients for Android, iOS, and desktop (browser-based). As far as I know, it's the only free (no monthly cost at all, and mobile device clients are free) push messaging service that has an open API.

I think this would be a very helpful notification method for Travis jobs.

I've done my best to provide complete code; I searched the repository for 'campfire' (which uses a very similar API) and duplicated those addons, making the appropriate changes. I also have companion PRs for the travis-core and docs repos.

I've tested the pushover notification code itself - the part that POSTs to the API - and confirmed it working. However, aside from rspec tests, there doesn't seem to be any way to *really* test this. I'm very excited to get this feature, so I'd be more than happy to help with any testing - including setting up a repo on my GitHub account for testing this, and adding whoever as collaborators. I can confirm the pushover notifications, or I can setup a Pushover account with the free 5-day trial of their browser-based client, and pass credentials on to anyone who needs them.

In short, I *really* want this, and I'll do whatever it takes to help get the required testing done.

Thanks,
Jason Antman