### PR TITLE
Add build type information to the GitHub commit status context

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -71,7 +71,7 @@ module Travis
 
           def context
             build_type = pull_request? ? "pr" : "push"
-            "continuous-integration/#{build_type}/travis-ci"
+            "continuous-integration/travis-ci/#{build_type}"
           end
 
           def state

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -46,7 +46,7 @@ module Travis
 
           def process_with_token(token)
             authenticated(token) do
-              GH.post(url, :state => state, :description => description, :target_url => target_url, context: 'continuous-integration/travis-ci')
+              GH.post(url, :state => state, :description => description, :target_url => target_url, :context => context)
             end
           rescue GH::Error(:response_status => 401)
             nil
@@ -67,6 +67,11 @@ module Travis
 
           def sha
             pull_request? ? request[:head_commit] : commit[:sha]
+          end
+
+          def context
+            build_type = pull_request? ? "pr" : "push"
+            "continuous-integration/#{build_type}/travis-ci"
           end
 
           def state

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -6,7 +6,7 @@ describe Travis::Addons::GithubStatus::Task do
   let(:subject)    { Travis::Addons::GithubStatus::Task }
   let(:url)        { '/repos/svenfuchs/minimal/statuses/62aae5f70ceee39123ef' }
   let(:target_url) { 'https://travis-ci.org/svenfuchs/minimal/builds/1' }
-  let(:payload) { Marshal.load(Marshal.dump(TASK_PAYLOAD)) }
+  let(:payload)    { Marshal.load(Marshal.dump(TASK_PAYLOAD)) }
   let(:io)         { StringIO.new }
 
   before do
@@ -19,31 +19,31 @@ describe Travis::Addons::GithubStatus::Task do
 
   it 'posts status info for a created build' do
     payload["build"]["state"] = 'created'
-    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a passed build' do
     payload["build"]["state"] = 'passed'
-    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a failed build' do
     payload["build"]["state"] = 'failed'
-    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a errored build' do
     payload['build']["state"] = 'errored'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a canceled build' do
     payload["build"]["state"] = 'canceled'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -19,31 +19,31 @@ describe Travis::Addons::GithubStatus::Task do
 
   it 'posts status info for a created build' do
     payload["build"]["state"] = 'created'
-    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a passed build' do
     payload["build"]["state"] = 'passed'
-    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a failed build' do
     payload["build"]["state"] = 'failed'
-    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a errored build' do
     payload['build']["state"] = 'errored'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a canceled build' do
     payload["build"]["state"] = 'canceled'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/pr/travis-ci').returns({})
     run
   end
 

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -19,31 +19,31 @@ describe Travis::Addons::GithubStatus::Task do
 
   it 'posts status info for a created build' do
     payload["build"]["state"] = 'created'
-    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a passed build' do
     payload["build"]["state"] = 'passed'
-    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a failed build' do
     payload["build"]["state"] = 'failed'
-    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a errored build' do
     payload['build']["state"] = 'errored'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 
   it 'posts status info for a canceled build' do
     payload["build"]["state"] = 'canceled'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
     run
   end
 

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -19,31 +19,31 @@ describe Travis::Addons::GithubStatus::Task do
 
   it 'posts status info for a created build' do
     payload["build"]["state"] = 'created'
-    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
     run
   end
 
   it 'posts status info for a passed build' do
     payload["build"]["state"] = 'passed'
-    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
     run
   end
 
   it 'posts status info for a failed build' do
     payload["build"]["state"] = 'failed'
-    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
     run
   end
 
   it 'posts status info for a errored build' do
     payload['build']["state"] = 'errored'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
     run
   end
 
   it 'posts status info for a canceled build' do
     payload["build"]["state"] = 'canceled'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/push/travis-ci').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
     run
   end
 


### PR DESCRIPTION
since we run builds for the PR and for the branch push, it makes sense to not swallow one of the commit status updates