### PR TITLE
Log email recipients if delivery is successful

### DIFF
--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -23,7 +23,7 @@ module Travis
           def process
             if recipients.any?
               Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-              info "Email sent to: #{recipients.map { |r| obfuscate_email_addrss(r) }.join(', ')}"
+              info "Email sent to: #{recipients.map { |r| obfuscate_email_address(r) }.join(', ')}"
             end
           rescue Net::SMTPServerBusy => e
             error("Could not send email to: #{recipients} (error: #{e.message})")
@@ -44,8 +44,8 @@ module Travis
             false
           end
 
-          def obfuscate_email_addrss(add)
-            match_data = add.match /^(?<name>[^@]+)@(?<domain>[^\.]+)\.(?<tld>[^\.]+)$/
+          def obfuscate_email_address(add)
+            match_data = add.match /^(?<name>[^@]+)@(?<domain>.+?)\.(?<tld>[^\.]+)$/
             name       = match_data[:name]
             domain     = match_data[:domain]
             tld        = match_data[:tld]

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -23,7 +23,7 @@ module Travis
           def process
             if recipients.any?
               Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-              info "Email sent to: #{recipients.map { |r| obfuscate_email_address(r) }.join(', ')}"
+              info "status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
             end
           rescue Net::SMTPServerBusy => e
             error("Could not send email to: #{recipients} (error: #{e.message})")

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -46,6 +46,8 @@ module Travis
 
           def obfuscate_email_address(add)
             match_data = add.match /^(?<name>[^@]+)@(?<domain>.+?)\.(?<tld>[^\.]+)$/
+            return add unless match_data
+
             name       = match_data[:name]
             domain     = match_data[:domain]
             tld        = match_data[:tld]

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -21,7 +21,10 @@ module Travis
         private
 
           def process
-            Mailer::Build.finished_email(payload, recipients, broadcasts).deliver if recipients.any?
+            if recipients.any?
+              Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
+              info "Email sent to: #{recipients.map { |r| obfuscate_email_addrss(r) }.join(', ')}"
+            end
           rescue Net::SMTPServerBusy => e
             error("Could not send email to: #{recipients} (error: #{e.message})")
             raise unless e.message =~ /Bad recipient address syntax/ || e.message =~ /Recipient address rejected/
@@ -39,6 +42,17 @@ module Travis
             mail.domain && mail.address == email && (tree.domain.dot_atom_text.elements.size > 1)
           rescue Exception => e
             false
+          end
+
+          def obfuscate_email_addrss(add)
+            match_data = add.match /^(?<name>[^@]+)@(?<domain>[^\.]+)\.(?<tld>[^\.]+)$/
+            name       = match_data[:name]
+            domain     = match_data[:domain]
+            tld        = match_data[:tld]
+            name       = name[0,3]   + '...' if name.length > 3
+            domain     = domain[0,3] + '...' if domain.length > 3
+
+            name + '@' + domain + '.' + tld
           end
       end
     end


### PR DESCRIPTION
Addresses are truncated if components are longer than 3 characters

There is no spec here; I do not think the email address format should
be specified.