### PR TITLE
update to jdk 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - jruby-1.7.22
   - jruby-head
 
+jdk:
+  - oraclejdk8
+
 sudo: false
 
 cache: bundler


### PR DESCRIPTION
Fixes: https://github.com/travis-ci/travis-ci/issues/4972

This just updates the tests to run on jdk 1.8.
