### PR TITLE
Log PR information

### DIFF
--- a/lib/travis/tasks/middleware/logging.rb
+++ b/lib/travis/tasks/middleware/logging.rb
@@ -20,17 +20,16 @@ module Travis
               data['repo'] = payload['repository']['slug']
             end
 
-            data['event'] = params['event'] if params['event']
             data['uuid'] = uuid
             data['job'] = payload['id'] if params['event'] && params['event'] =~ /^job/
             data['time'] = "%.3f" % (time/1000) if time
             data['jid'] = message['jid']
 
             if payload['pull_request']
-              data['pull_request'] = 'yes'
+              data['event'] = 'pull_request'
               data['pull_request_number'] = payload['pull_request_number']
             else
-              data['pull_request'] = 'no'
+              data['event'] = 'push'
             end
           end
           log(data)

--- a/lib/travis/tasks/middleware/logging.rb
+++ b/lib/travis/tasks/middleware/logging.rb
@@ -25,6 +25,13 @@ module Travis
             data['job'] = payload['id'] if params['event'] && params['event'] =~ /^job/
             data['time'] = "%.3f" % (time/1000) if time
             data['jid'] = message['jid']
+
+            if payload['pull_request']
+              data['pull_request'] = 'yes'
+              data['pull_request_number'] = payload['pull_request_number']
+            else
+              data['pull_request'] = 'no'
+            end
           end
           log(data)
         end

--- a/lib/travis/tasks/middleware/logging.rb
+++ b/lib/travis/tasks/middleware/logging.rb
@@ -25,9 +25,9 @@ module Travis
             data['time'] = "%.3f" % (time/1000) if time
             data['jid'] = message['jid']
 
-            if payload['pull_request']
+            if payload['build'] && payload['build']['pull_request']
               data['event'] = 'pull_request'
-              data['pull_request_number'] = payload['pull_request_number']
+              data['pull_request_number'] = payload['build']['pull_request_number']
             else
               data['event'] = 'push'
             end

--- a/lib/travis/tasks/middleware/logging.rb
+++ b/lib/travis/tasks/middleware/logging.rb
@@ -30,7 +30,7 @@ module Travis
         end
 
         def log(data)
-          Travis.logger.info(data.map {|k, v| "#{k}=#{v}"}.join(" "))
+          Travis.logger.info(data.map {|k, v| "#{k}=#{v}" if v}.join(" "))
         end
       end
     end


### PR DESCRIPTION
A couple of notifiers (Slack and HipChat) which sends notifications for PR builds, while others do not.

We want to have consistency, but we also want to know how users are using these notifications. This PR adds that information to the logs.