### PR TITLE
Rescue Faraday::TimeoutError

### DIFF
--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -18,6 +18,9 @@ module Travis
             Array(targets).each do |target|
               begin
                 send_webhook(target)
+              rescue Faraday::TimeoutError => e
+                error "task=webhook status=failed url=#{target}"
+                errors[target] = e.message
               rescue => e
                 error "task=webhook status=failed url=#{target}"
                 errors[target] = e.message


### PR DESCRIPTION
This should solve https://github.com/travis-ci/travis-ci/issues/3192 . When the destination URL is filtered and times out, Faraday raises a "Faraday::Timeout" error that is not rescued by a generic rescue.