### PR TITLE
Let Faraday handle HTTP timeouts

### DIFF
--- a/lib/travis/addons/campfire/task.rb
+++ b/lib/travis/addons/campfire/task.rb
@@ -26,19 +26,20 @@ module Travis
         private
 
           def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
-            targets.each { |target| send_message(target, message) }
+            targets.each { |target| send_message(target, message, timeout) }
           end
 
-          def send_message(target, lines)
+          def send_message(target, lines, timeout)
             url, token = parse(target)
             http.basic_auth(token, 'X')
-            lines.each { |line| send_line(url, line) }
+            lines.each { |line| send_line(url, line, timeout) }
           rescue => e
             Travis.logger.info("Error connecting to Campfire service for #{target}: #{e.message}")
           end
 
-          def send_line(url, line)
+          def send_line(url, line, timeout)
             http.post(url) do |r|
+              r.options.timeout = timeout
               r.body = MultiJson.encode({ message: { body: line } })
               r.headers['Content-Type'] = 'application/json'
             end

--- a/lib/travis/addons/campfire/task.rb
+++ b/lib/travis/addons/campfire/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             targets.each { |target| send_message(target, message, timeout) }
           end
 

--- a/lib/travis/addons/campfire/task.rb
+++ b/lib/travis/addons/campfire/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             targets.each { |target| send_message(target, message) }
           end
 

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -20,7 +20,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             if recipients.any?
               Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
               info "type=email status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -20,7 +20,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             if recipients.any?
               Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
               info "type=email status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"

--- a/lib/travis/addons/flowdock/task.rb
+++ b/lib/travis/addons/flowdock/task.rb
@@ -42,7 +42,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             targets.each { |target| send_message(target) }
           end
 

--- a/lib/travis/addons/flowdock/task.rb
+++ b/lib/travis/addons/flowdock/task.rb
@@ -42,7 +42,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             targets.each { |target| send_message(target) }
           end
 

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -28,7 +28,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             info("type=github_status build=#{build[:id]} repo=#{repository[:slug]} state=#{state} commit=#{sha}")
 
             tokens.each do |username, token|

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -28,7 +28,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             info("type=github_status build=#{build[:id]} repo=#{repository[:slug]} state=#{state} commit=#{sha}")
 
             tokens.each do |username, token|

--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             targets.each do |target|
               helper = HttpHelper.new(target)
               if helper.url.nil?

--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             targets.each do |target|
               helper = HttpHelper.new(target)
               if helper.url.nil?

--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -33,14 +33,15 @@ module Travis
                 next
               end
 
-              send_message(helper, message)
+              send_message(helper, message, timeout = timeout)
 
             end
           end
 
-          def send_message(helper, message)
+          def send_message(helper, message, timeout)
             message.each do |line|
               response = http.post(helper.url) do |r|
+                r.options.timeout = timeout
                 r.body = helper.body(line: line, color: color, message_format: message_format, notify: notify)
                 helper.add_content_type!(r.headers)
               end

--- a/lib/travis/addons/irc/task.rb
+++ b/lib/travis/addons/irc/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             # Notifications to the same host are grouped so that they can be sent with a single connection
             parsed_channels.each do |server, channels|
               host, port, ssl = *server

--- a/lib/travis/addons/irc/task.rb
+++ b/lib/travis/addons/irc/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             # Notifications to the same host are grouped so that they can be sent with a single connection
             parsed_channels.each do |server, channels|
               host, port, ssl = *server

--- a/lib/travis/addons/pushover/task.rb
+++ b/lib/travis/addons/pushover/task.rb
@@ -14,7 +14,7 @@ module Travis
         def message
           @message ||= Util::Template.new(template, payload).interpolate
         end
-        
+
         def users
           params[:users]
         end
@@ -22,11 +22,11 @@ module Travis
         def api_key
           params[:api_key]
         end
-        
+
         private
 
-          def process
-            token = api_key        
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+            token = api_key
             users.each { |user| send_message(user, message, token) }
           end
 

--- a/lib/travis/addons/pushover/task.rb
+++ b/lib/travis/addons/pushover/task.rb
@@ -27,16 +27,17 @@ module Travis
 
           def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             token = api_key
-            users.each { |user| send_message(user, message, token) }
+            users.each { |user| send_message(user, message, token, timeout) }
           end
 
-          def send_message(user, message, token)
+          def send_message(user, message, token, timeout)
             # this is roughly per https://pushover.net/faq#library-ruby
             msg_h = {:token => token, :user => user, :message => message}
             if is_failure
               msg_h[:sound] = 'falling'
             end
             http.post("https://api.pushover.net/1/messages.json") do |r|
+              r.options.timeout = timeout
               r.body = msg_h
             end
           rescue => e

--- a/lib/travis/addons/pushover/task.rb
+++ b/lib/travis/addons/pushover/task.rb
@@ -25,7 +25,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             token = api_key
             users.each { |user| send_message(user, message, token, timeout) }
           end

--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -6,7 +6,7 @@ module Travis
         BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}"
         PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request_number}> by %{author} %{result} in %{duration}"
 
-        def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+        def process(timeout)
           targets.each do |target|
             if illegal_format?(target)
               warn "task=slack build=#{payload[:id]} result=invalid_target target=#{target}"

--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -11,7 +11,7 @@ module Travis
             if illegal_format?(target)
               warn "task=slack build=#{payload[:id]} result=invalid_target target=#{target}"
             else
-              send_message(target)
+              send_message(target, timeout)
             end
           end
         end
@@ -24,9 +24,10 @@ module Travis
           !target.match(/^[a-zA-Z0-9-]+:[a-zA-Z0-9_-]+(#.+)?$/)
         end
 
-        def send_message(target)
+        def send_message(target, timeout)
           url, channel = parse(target)
           http.post(url) do |request|
+            request.options.timeout = timeout
             request.body = MultiJson.encode(message(channel))
           end
         end

--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -6,7 +6,7 @@ module Travis
         BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}"
         PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request_number}> by %{author} %{result} in %{duration}"
 
-        def process
+        def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
           targets.each do |target|
             if illegal_format?(target)
               warn "task=slack build=#{payload[:id]} result=invalid_target target=#{target}"

--- a/lib/travis/addons/sqwiggle/task.rb
+++ b/lib/travis/addons/sqwiggle/task.rb
@@ -26,7 +26,7 @@ module Travis
           (config[:template] rescue nil) || DEFAULT_TEMPLATE
         end
 
-        def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+        def process(timeout)
           targets.each do |target|
             send_message(*parse(target), timeout)
           end

--- a/lib/travis/addons/sqwiggle/task.rb
+++ b/lib/travis/addons/sqwiggle/task.rb
@@ -26,7 +26,7 @@ module Travis
           (config[:template] rescue nil) || DEFAULT_TEMPLATE
         end
 
-        def process
+        def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
           targets.each do |target|
             send_message(*parse(target))
           end

--- a/lib/travis/addons/sqwiggle/task.rb
+++ b/lib/travis/addons/sqwiggle/task.rb
@@ -28,12 +28,13 @@ module Travis
 
         def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
           targets.each do |target|
-            send_message(*parse(target))
+            send_message(*parse(target), timeout)
           end
         end
 
-        def send_message(url, stream_id)
+        def send_message(url, stream_id, timeout)
           http.post(url) do |r|
+            r.options.timeout = timeout
             r.body = MultiJson.encode(sqwiggle_payload(stream_id))
             r.headers['Content-Type'] = 'application/json'
           end

--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -12,7 +12,7 @@ module Travis
 
         private
 
-          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
+          def process(timeout)
             errors = {}
 
             Array(targets).each do |target|

--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -12,7 +12,7 @@ module Travis
 
         private
 
-          def process
+          def process(timeout = Travis::Task::DEFAULT_TIMEOUT)
             errors = {}
 
             Array(targets).each do |target|

--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -17,7 +17,7 @@ module Travis
 
             Array(targets).each do |target|
               begin
-                send_webhook(target)
+                send_webhook(target, timeout)
               rescue => e
                 error "task=webhook status=failed url=#{target}"
                 errors[target] = e.message
@@ -29,8 +29,9 @@ module Travis
             end
           end
 
-          def send_webhook(target)
+          def send_webhook(target, timeout)
             response = http.post(target) do |req|
+              req.options.timeout = timeout
               req.body = { payload: payload.except(:params).to_json }
               uri = URI(target)
               if uri.user && uri.password

--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -34,7 +34,7 @@ module Travis
     end
 
     def run
-      process(params[:timeout])
+      process(params[:timeout] || DEFAULT_TIMEOUT)
     end
 
     private

--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -12,6 +12,8 @@ module Travis
 
     class_attribute :run_local
 
+    DEFAULT_TIMEOUT = 60
+
     class << self
       extend Exceptions::Handling
 
@@ -32,9 +34,7 @@ module Travis
     end
 
     def run
-      timeout after: params[:timeout] || 60 do
-        process
-      end
+      process(params[:timeout])
     end
 
     private
@@ -78,10 +78,6 @@ module Travis
 
       def http_options
         { ssl: Travis.config.ssl.compact }
-      end
-
-      def timeout(options = { after: 60 }, &block)
-        Timeout::timeout(options[:after], &block)
       end
   end
 end


### PR DESCRIPTION
This PR changes the way we handle timeouts.

We wrapped the tasks request inside a `Timeout::timeout` call, which raised `Timeout::Error` which we couldn't rescue in Sidekiq.

By letting Faraday handle the exception, we can rescue the timeouts.

Notice that the timeout is not respected by the email nor the IRC notifier, since these do not rely on HTTP.