### PR TITLE
Replace duration with elapsed_time in Slack Notifications

### DIFF
--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -3,8 +3,8 @@ module Travis
     module Slack
       class Task < Travis::Task
 
-        BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration}"
-        PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request_number}> by %{author} %{result} in %{duration}"
+        BRANCH_BUILD_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{elapsed_time}"
+        PULL_REQUEST_MESSAGE_TEMPLATE = "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} in PR <%{pull_request_url}|#%{pull_request_number}> by %{author} %{result} in %{elapsed_time}"
 
         def process(timeout)
           targets.each do |target|


### PR DESCRIPTION
This is probably controversial, but I would argue this is better.

See, e.g https://github.com/travis-ci/travis-ci/issues/5811

@BanzaiMan 