### PR TITLE
Merge in GitHub SSL settings the similar to the way API does

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -91,7 +91,7 @@ module Travis
           end
 
           def http_options(token)
-            super().merge(token: token, headers: headers)
+            super().merge(token: token, headers: headers, ssl: (Travis.config.github.ssl || {}).to_hash.compact)
           end
 
           def headers


### PR DESCRIPTION
Testing the latest version of Travis Enterprise against the latest version of GitHub Enterprise I noticed some issues when talking to a GHE instance with self signed certificates. Namely this error: 

`Faraday::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed` 

This is consistent with the errors we saw in other places on Enterprise when disabling cert verification wasn't being properly passed (not passing `ssl: { verify: false }` to Faraday), and indeed when looking at [`travis/task.rb`](https://github.com/travis-ci/travis-tasks/blob/6fad227/lib/travis/task.rb#L88-L90) and [`travis/addons/github_status/task.rb`](https://github.com/travis-ci/travis-tasks/blob/6fad227/lib/travis/addons/github_status/task.rb#L93-L95) we weren't pulling in those settings. 

This PR fixes this by merging in any GitHub SSL settings much in the [same way API does](https://github.com/travis-ci/travis-api/blob/e3d56ec/lib/travis/api/v3/github.rb#L13). 

Once this is merged into master, I'll backport the changes to the current Enterprise branch. 