### PR TITLE
Backport #60 for 2.0: Merge in GitHub SSL settings the similar to the way API does

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -91,7 +91,7 @@ module Travis
           end
 
           def http_options(token)
-            super().merge(token: token, headers: headers)
+            super().merge(token: token, headers: headers, ssl: (Travis.config.github.ssl || {}).to_hash.compact)
           end
 
           def headers


### PR DESCRIPTION
This PR backports #60 to the `te-dev` branch.

