### PR TITLE
Raise error on missing token for webhooks

### DIFF
--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -1,6 +1,7 @@
 module Travis
   module Addons
     module Webhook
+      class InvalidTokenError < StandardError; end
       class WebhookError < StandardError; end
 
       # Sends build notifications to webhooks as defined in the configuration
@@ -50,7 +51,8 @@ module Travis
           end
 
           def authorization
-            Digest::SHA2.hexdigest(repo_slug + params[:token].to_s)
+            raise InvalidTokenError if missing_token?
+            Digest::SHA2.hexdigest(repo_slug + params[:token])
           end
 
           def log_success(response)
@@ -63,6 +65,10 @@ module Travis
 
           def repo_slug
             repository.values_at(:owner_name, :name).join('/')
+          end
+
+          def missing_token?
+            params[:token].nil? || params[:token].empty?
           end
       end
     end

--- a/spec/addons/webhook/task_spec.rb
+++ b/spec/addons/webhook/task_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'rack'
+require "spec_helper"
+require "rack"
 
 describe Travis::Addons::Webhook::Task do
   include Travis::Testing::Stubs
@@ -8,7 +8,7 @@ describe Travis::Addons::Webhook::Task do
   let(:http)    { Faraday::Adapter::Test::Stubs.new }
   let(:client)  { Faraday.new { |f| f.request :url_encoded; f.adapter :test, http } }
   let(:payload) { Marshal.load(Marshal.dump(WEBHOOK_PAYLOAD)) }
-  let(:repo_slug) { 'svenfuchs/minimal' }
+  let(:repo_slug) { "svenfuchs/minimal" }
 
   before do
     Travis.config.notifications = [:webhook]
@@ -17,17 +17,17 @@ describe Travis::Addons::Webhook::Task do
   end
 
   def run(targets)
-    subject.new(payload, targets: targets, token: '123456').run
+    subject.new(payload, targets: targets, token: "123456").run
   end
 
-  it 'posts to the given targets, with the given payload and the given access token' do
-    targets = ['http://one.webhook.com/path', 'http://second.webhook.com/path']
+  it "posts to the given targets, with the given payload and the given access token" do
+    targets = ["http://one.webhook.com/path", "http://second.webhook.com/path"]
 
     targets.each do |url|
       uri = URI.parse(url)
       http.post uri.path do |env|
         env[:url].host.should == uri.host
-        env[:request_headers]['Authorization'].should == authorization_for(repo_slug, '123456')
+        env[:request_headers]["Authorization"].should == authorization_for(repo_slug, "123456")
         payload_from(env).keys.sort.should == payload.keys.map(&:to_s).sort
       end
     end
@@ -55,9 +55,9 @@ describe Travis::Addons::Webhook::Task do
     uri = URI.parse(url)
     http.post uri.path do |env|
       env[:url].host.should == uri.host
-      auth = env[:request_headers]['Authorization']
-      auth.should == 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
-      auth.should == Faraday::Request::BasicAuthentication.header('Aladdin', 'open sesame')
+      auth = env[:request_headers]["Authorization"]
+      auth.should == "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+      auth.should == Faraday::Request::BasicAuthentication.header("Aladdin", "open sesame")
       payload_from(env).keys.sort.should == payload.keys.map(&:to_s).sort
     end
 
@@ -65,12 +65,12 @@ describe Travis::Addons::Webhook::Task do
     http.verify_stubbed_calls
   end
 
-  it 'includes a Travis-Repo-Slug header' do
-    url = 'https://one.webhook.com/path'
+  it "includes a Travis-Repo-Slug header" do
+    url = "https://one.webhook.com/path"
     uri = URI.parse(url)
     http.post uri.path do |env|
       env[:url].host.should == uri.host
-      env[:request_headers]['Travis-Repo-Slug'].should == repo_slug
+      env[:request_headers]["Travis-Repo-Slug"].should == repo_slug
       payload_from(env).keys.sort.should == payload.keys.map(&:to_s).sort
     end
 
@@ -79,7 +79,7 @@ describe Travis::Addons::Webhook::Task do
   end
 
   def payload_from(env)
-    JSON.parse(Rack::Utils.parse_query(env[:body])['payload'])
+    JSON.parse(Rack::Utils.parse_query(env[:body])["payload"])
   end
 
   def authorization_for(slug, token)

--- a/spec/addons/webhook/task_spec.rb
+++ b/spec/addons/webhook/task_spec.rb
@@ -36,8 +36,22 @@ describe Travis::Addons::Webhook::Task do
     http.verify_stubbed_calls
   end
 
-  it 'posts with automatically-parsed basic auth credentials' do
-    url = 'https://Aladdin:open%20sesame@fancy.webhook.com/path'
+  context "when request token is invalid" do
+    it "raises an error when token is an empty string" do
+      expect{
+        subject.new(payload, token: "").send(:authorization)
+      }.to raise_error(Travis::Addons::Webhook::InvalidTokenError)
+    end
+
+    it "raises an error when token is nil" do
+      expect{
+        subject.new(payload, token: nil).send(:authorization)
+      }.to raise_error(Travis::Addons::Webhook::InvalidTokenError)
+    end
+  end
+
+  it "posts with automatically-parsed basic auth credentials" do
+    url = "https://Aladdin:open%20sesame@fancy.webhook.com/path"
     uri = URI.parse(url)
     http.post uri.path do |env|
       env[:url].host.should == uri.host
@@ -60,7 +74,7 @@ describe Travis::Addons::Webhook::Task do
       payload_from(env).keys.sort.should == payload.keys.map(&:to_s).sort
     end
 
-    subject.new(payload, targets: [url]).run
+    subject.new(payload, targets: [url], token: "abc123").run
     http.verify_stubbed_calls
   end
 


### PR DESCRIPTION
... and change some quotation marks.

This is in relation to https://github.com/travis-ci/travis-ci/issues/6435

Currently, when an invalid token is passed to a webhook task,
if we are not using Basic Auth, we will attempt to craft an
Authorization header that users then compare to ensure that the request
has come from Travis.

We use the `token` as well as the `slug` to calculate the value of the
Authorization header. When token is nil/"", this breaks consuming
clients' code, as the signature we calculate is no longer valid.

To ensure this doesn't happen again in the future, we'll raise an
exception whenever the token we are passed is unusable. This won't
impact other code paths, but will let us know if this problem crops up
again in the future.