### PR TITLE
Removed the deprecated slug/token auth code

### DIFF
--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -37,30 +37,34 @@ module Travis
             response = http.post(target) do |req|
               req.options.timeout = timeout
               req.body = { payload: payload.except(:params).to_json }
-              uri = URI(target)
-              if uri.user && uri.password
-                req.headers['Authorization'] =
-                  Faraday::Request::BasicAuthentication.header(
-                    URI.unescape(uri.user), URI.unescape(uri.password)
-                  )
-              else
-                req.headers['Authorization'] = authorization
-              end
-              if add_signature?
-                req.headers['Signature'] = signature(req.body[:payload])
-              end
-              req.headers['Travis-Repo-Slug'] = repo_slug
-              req.headers['User-Agent'] = "Travis CI Notifications"
+              add_headers(req, target, req.body[:payload])
             end
 
-            response.success? ? log_success(response) : log_error(response)
+            if response.success?
+              log_success(response)
+            else
+              log_error(response)
+            end
           rescue URI::InvalidURIError => e
             error "task=webhook status=invalid_uri build=#{payload[:id]} slug=#{repo_slug} url=#{target}"
           end
 
-          def authorization
-            raise InvalidTokenError if missing_token?
-            Digest::SHA2.hexdigest(repo_slug + params[:token])
+          def add_headers(request, target, payload)
+            uri = URI(target)
+            if uri.user && uri.password
+              request.headers['Authorization'] = basicauth(uri.user, uri.password)
+            end
+            if add_signature?
+              request.headers['Signature'] = signature(payload)
+            end
+            request.headers['Travis-Repo-Slug'] = repo_slug
+            request.headers['User-Agent'] = "Travis CI Notifications"
+          end
+
+          def basicauth(user, password)
+            Faraday::Request::BasicAuthentication.header(
+              URI.unescape(user), URI.unescape(password)
+            )
           end
 
           def add_signature?
@@ -82,10 +86,6 @@ module Travis
 
           def repo_slug
             repository.values_at(:owner_name, :name).join('/')
-          end
-
-          def missing_token?
-            params[:token].nil? || params[:token].empty?
           end
       end
     end

--- a/spec/addons/webhook/task_spec.rb
+++ b/spec/addons/webhook/task_spec.rb
@@ -37,20 +37,6 @@ describe Travis::Addons::Webhook::Task do
     http.verify_stubbed_calls
   end
 
-  context "when request token is invalid" do
-    it "raises an error when token is an empty string" do
-      expect{
-        subject.new(payload, token: "").send(:authorization)
-      }.to raise_error(Travis::Addons::Webhook::InvalidTokenError)
-    end
-
-    it "raises an error when token is nil" do
-      expect{
-        subject.new(payload, token: nil).send(:authorization)
-      }.to raise_error(Travis::Addons::Webhook::InvalidTokenError)
-    end
-  end
-
   it "posts with automatically-parsed basic auth credentials" do
     url = "https://Aladdin:open%20sesame@fancy.webhook.com/path"
     uri = URI.parse(url)


### PR DESCRIPTION
# DO NOT merge until the code is announced deprecated.

Restores #67, which was inadvertently merged prematurely and subsequently reverted.
