### PR TITLE
Remove deprecated slug/token auth code

### DIFF
--- a/lib/travis/addons/webhook/task.rb
+++ b/lib/travis/addons/webhook/task.rb
@@ -36,29 +36,34 @@ module Travis
             response = http.post(target) do |req|
               req.options.timeout = timeout
               req.body = { payload: payload.except(:params).to_json }
-              uri = URI(target)
-              if uri.user && uri.password
-                req.headers['Authorization'] =
-                  Faraday::Request::BasicAuthentication.header(
-                    URI.unescape(uri.user), URI.unescape(uri.password)
-                  )
-              else
-                req.headers['Authorization'] = authorization
-              end
-              if add_signature?
-                req.headers['Signature'] = signature(req.body[:payload])
-              end
-              req.headers['Travis-Repo-Slug'] = repo_slug
-              req.headers['User-Agent'] = "Travis CI Notifications"
+              add_headers(req, target, req.body[:payload])
             end
 
-            response.success? ? log_success(response) : log_error(response)
+            if response.success?
+              log_success(response)
+            else
+              log_error(response)
+            end
           rescue URI::InvalidURIError => e
             error "task=webhook status=invalid_uri build=#{payload[:id]} slug=#{repo_slug} url=#{target}"
           end
 
-          def authorization
-            Digest::SHA2.hexdigest(repo_slug + params[:token].to_s)
+          def add_headers(request, target, payload)
+            uri = URI(target)
+            if uri.user && uri.password
+              request.headers['Authorization'] = basicauth(uri.user, uri.password)
+            end
+            if add_signature?
+              request.headers['Signature'] = signature(payload)
+            end
+            request.headers['Travis-Repo-Slug'] = repo_slug
+            request.headers['User-Agent'] = "Travis CI Notifications"
+          end
+
+          def basic_auth(user, password)
+            Faraday::Request::BasicAuthentication.header(
+              URI.unescape(user), URI.unescape(password)
+            )
           end
 
           def add_signature?

--- a/spec/addons/webhook/task_spec.rb
+++ b/spec/addons/webhook/task_spec.rb
@@ -37,22 +37,6 @@ describe Travis::Addons::Webhook::Task do
     http.verify_stubbed_calls
   end
 
-  it 'posts with automatically-parsed basic auth credentials' do
-    url = 'https://Aladdin:open%20sesame@fancy.webhook.com/path'
-    uri = URI.parse(url)
-    http.post uri.path do |env|
-      env[:url].host.should == uri.host
-      auth = env[:request_headers]['Authorization']
-      auth.should == 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
-      auth.should == Faraday::Request::BasicAuthentication.header('Aladdin', 'open sesame')
-      payload_from(env).keys.sort.should == payload.keys.map(&:to_s).sort
-      200
-    end
-
-    subject.new(payload, targets: [url]).run
-    http.verify_stubbed_calls
-  end
-
   it 'includes a Travis-Repo-Slug header' do
     url = 'https://one.webhook.com/path'
     uri = URI.parse(url)


### PR DESCRIPTION
This commit redos https://github.com/travis-ci/travis-tasks/pull/67,
which was inadvertently merged and subsequently reverted in August.

https://github.com/travis-ci/travis-tasks/pull/69 was an attempt to
re-apply for November, but the codebase changed enough to make the
conflict resolution a bit hairy.

So this is a commit to just basically redo what was originally intended.