### PR TITLE
better error handling for suspended github users

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -52,7 +52,8 @@ module Travis
             error("type=github_status build=#{build[:id]} repo=#{repository[:slug]} state=#{state} commit=#{sha} response_status=401 reason=incorrect_auth")
             nil
           rescue GH::Error(:response_status => 403)
-            raise if Travis.config.env == 'production'
+            error("type=github_status build=#{build[:id]} repo=#{repository[:slug]} state=#{state} commit=#{sha} response_status=403 reason=incorrect_auth_or_suspended_acct")
+            nil
           rescue GH::Error(:response_status => 404)
             error("type=github_status build=#{build[:id]} repo=#{repository[:slug]} state=#{state} commit=#{sha} response_status=404 reason=repo_not_found_or_incorrect_auth")
             nil

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -73,6 +73,16 @@ describe Travis::Addons::GithubStatus::Task do
     io.string.should include('reason=maximum_number_of_statuses')
   end
 
+  it 'does not raise if a 403 error was returned by GH' do
+    error = { response_status: 403 }
+    GH.stubs(:post).raises(GH::Error.new('failed', nil, error))
+    expect {
+      run
+    }.not_to raise_error
+    io.string.should include('response_status=403')
+    io.string.should include('reason=incorrect_auth_or_suspended_acct')
+  en
+
   it 'does not raise if a 404 error was returned by GH' do
     error = { response_status: 404 }
     GH.stubs(:post).raises(GH::Error.new('failed', nil, error))

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -81,7 +81,7 @@ describe Travis::Addons::GithubStatus::Task do
     }.not_to raise_error
     io.string.should include('response_status=403')
     io.string.should include('reason=incorrect_auth_or_suspended_acct')
-  en
+  end
 
   it 'does not raise if a 404 error was returned by GH' do
     error = { response_status: 404 }


### PR DESCRIPTION
When a user is suspended in GitHub Enterprise, the response code from the github api is 403, which then causes us not to try other oauth tokens.

This change modifies this error handling behaviour to instead log a message and try the next oauth token.