### PR TITLE
Add utm params to inbound build urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
-gem 'travis-support',  github: 'travis-ci/travis-support'
+gem 'travis-support',  git: 'https://github.com/travis-ci/travis-support'
 gem 'travis-config',   '~> 1.0.6'
 
 gem 'sidekiq',         '~> 4.0.0'
@@ -11,7 +11,7 @@ gem 'sentry-raven'
 gem 'metriks'
 gem 'metriks-librato_metrics'
 
-gem 'jemalloc', github: 'joshk/jemalloc-rb'
+gem 'jemalloc', git: 'https://github.com/joshk/jemalloc-rb'
 
 gem 'gh'
 gem 'aws-sdk'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 
 gem 'travis-support',  git: 'https://github.com/travis-ci/travis-support'
-gem 'travis-config',   '~> 1.0.6'
+gem 'travis-config',   '~> 1.1.0'
 
 gem 'sidekiq',         '~> 4.0.0'
 gem 'redis-namespace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
-  remote: git://github.com/joshk/jemalloc-rb.git
-  revision: 870facda6891ffd9a0b44195b45c485192413742
+  remote: https://github.com/joshk/jemalloc-rb
+  revision: 8c9dbef98f6bd4f96b371ec336b7e0c4fdc02d49
   specs:
-    jemalloc (1.0.1)
+    jemalloc (1.4.5)
 
 GIT
-  remote: git://github.com/travis-ci/travis-support.git
-  revision: 2cd02d2a06fdd1e2fc2f129148c168b56f7c190f
+  remote: https://github.com/travis-ci/travis-support
+  revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
   specs:
     travis-support (0.0.1)
 
@@ -206,5 +206,8 @@ DEPENDENCIES
   travis-support!
   webmock (~> 1.8.0)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     guard-rspec (4.3.1)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
-    hashr (2.0.0)
+    hashr (2.0.1)
     hike (1.2.3)
     hitimes (1.2.3)
     i18n (0.7.0)
@@ -172,7 +172,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.19.1)
     tilt (1.4.1)
-    travis-config (1.0.12)
+    travis-config (1.1.2)
       hashr (~> 2.0.0)
     treetop (1.4.15)
       polyglot
@@ -202,7 +202,7 @@ DEPENDENCIES
   rspec (~> 2.14.0)
   sentry-raven
   sidekiq (~> 4.0.0)
-  travis-config (~> 1.0.6)
+  travis-config (~> 1.1.0)
   travis-support!
   webmock (~> 1.8.0)
 

--- a/lib/travis/addons/email/mailer/helpers.rb
+++ b/lib/travis/addons/email/mailer/helpers.rb
@@ -14,8 +14,27 @@ module Travis
             "data:#{type};base64,#{data}"
           end
 
+          def repo_url(repo)
+            url = "https://#{Travis.config.host}/#{repo.slug}"
+            Travis.config.utm ? with_utm(url) :url
+          end
+
+          def branch_url(repo, branch)
+            "#{Travis.config.github.url}/#{repo.slug}/tree/#{branch}"
+          end
+
           def repository_build_url(options)
-            [Travis.config.http_host, options[:slug], 'builds', options[:id]].join('/')
+            config = Travis.config
+            url = [config.http_host, options[:slug], 'builds', options[:id]].join('/')
+            config.utm ? with_utm(url) :url
+          end
+
+          def with_utm(url)
+            with_query_params(url, utm_source: :email, utm_medium: :notification)
+          end
+
+          def with_query_params(url, params)
+            "#{url}?#{params.map { |pair| pair.join('=') }.join('&')}"
           end
 
           def title(repository)

--- a/lib/travis/addons/email/mailer/views/build/finished_email.html.erb
+++ b/lib/travis/addons/email/mailer/views/build/finished_email.html.erb
@@ -310,7 +310,7 @@
     <div id="body">
       <table class="repository" background="" style="">
         <tr style="">
-          <td><img src="<%= @repository.owner_avatar_url %>?s=40&d=<%= CGI.escape("https://#{Travis.config.assets.host}/images/mailer/mascot-avatar-40px.png") %>"/> <span><strong><%= link_to @repository.slug.gsub(/\//, " / "), "https://#{Travis.config.host}/#{@repository.slug}" -%></strong> (<%= link_to @commit.branch, "#{Travis.config.github.url}/#{@repository.slug}/tree/#{@commit.branch}" -%>)</span></td>
+          <td><img src="<%= @repository.owner_avatar_url %>?s=40&d=<%= CGI.escape("https://#{Travis.config.assets.host}/images/mailer/mascot-avatar-40px.png") %>"/> <span><strong><%= link_to @repository.slug.gsub(/\//, " / "), repo_url(@repository) -%></strong> (<%= link_to @commit.branch, branch_url(@repository, @commit.branch) -%>)</span></td>
         </tr>
       </table>
       <div id="build" class="<%= build_email_css_class(@build) %>">

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -67,7 +67,7 @@ module Travis
           end
 
           def target_url
-            "#{Travis.config.http_host}/#{repository[:slug]}/builds/#{build[:id]}"
+            with_utm("#{Travis.config.http_host}/#{repository[:slug]}/builds/#{build[:id]}", :github_status)
           end
 
           def sha

--- a/lib/travis/addons/hipchat/task.rb
+++ b/lib/travis/addons/hipchat/task.rb
@@ -20,7 +20,7 @@ module Travis
         end
 
         def message
-          @messages ||= template.map { |line| Util::Template.new(line, payload).interpolate }
+          @messages ||= template.map { |line| Util::Template.new(line, payload, source: :hipchat).interpolate }
         end
 
         private

--- a/lib/travis/addons/slack/task.rb
+++ b/lib/travis/addons/slack/task.rb
@@ -62,7 +62,7 @@ module Travis
 
         def message_text
           lines = Array(template_from_config || default_template)
-          lines.map {|line| Util::Template.new(line, payload).interpolate}.join("\n")
+          lines.map {|line| Util::Template.new(line, payload, source: :slack).interpolate}.join("\n")
         end
 
         def color

--- a/lib/travis/addons/util/template.rb
+++ b/lib/travis/addons/util/template.rb
@@ -5,11 +5,12 @@ module Travis
   module Addons
     module Util
       class Template
-        attr_reader :template, :data
+        attr_reader :template, :data, :opts
 
-        def initialize(template, data)
+        def initialize(template, data, opts = {})
           @template = template
           @data = data.deep_symbolize_keys
+          @opts = opts
         end
 
         def interpolate
@@ -55,7 +56,18 @@ module Travis
 
         def build_url
           url = [Travis.config.http_host, data[:repository][:slug], 'builds', data[:build][:id]].join('/')
-          short_urls? ? shorten_url(url) : url
+          url = short_urls? ? shorten_url(url) : url
+          url = with_query_params(url, utm) if Travis.config.utm && opts[:source]
+          url
+        end
+
+        def utm
+          { utm_source: opts[:source], utm_medium: :notification }
+        end
+
+        def with_query_params(url, params)
+          url = "#{url}?#{params.map { |pair| pair.join('=') }.join('&')}" if params.any?
+          url
         end
 
         def pull_request_url

--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -78,6 +78,15 @@ module Travis
         end
       end
 
+      def with_utm(url, source)
+        utm = { utm_source: source, utm_medium: :notification }
+        Travis.config.utm ? with_query_params(url, utm) : url
+      end
+
+      def with_query_params(url, params)
+        "#{url}?#{params.map { |pair| pair.join('=') }.join('&')}"
+      end
+
       def http
         @http ||= Faraday.new(http_options) do |f|
           f.request :url_encoded

--- a/lib/travis/tasks/config.rb
+++ b/lib/travis/tasks/config.rb
@@ -23,6 +23,7 @@ module Travis
              ssl:     { },
              email:   { },
              webhook: { },
+             utm:     Travis.env == 'test',
              assets:  { host: HOSTS[Travis.env.to_sym] }
 
       default _access: [:key]

--- a/spec/addons/campfire/task_spec.rb
+++ b/spec/addons/campfire/task_spec.rb
@@ -21,7 +21,7 @@ describe Travis::Addons::Campfire::Task do
     message = [
       '[travis-ci] svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       '[travis-ci] Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
-      '[travis-ci] Build details: https://travis-ci.org/svenfuchs/minimal/builds/1'
+      '[travis-ci] Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=campfire&utm_medium=notification'
     ]
 
     expect_campfire('account-1', '1234', 'token-1', message)

--- a/spec/addons/email/mailer/build_spec.rb
+++ b/spec/addons/email/mailer/build_spec.rb
@@ -57,15 +57,16 @@ describe Travis::Addons::Email::Mailer::Build do
         Author: まつもとゆきひろ a.k.a. Matz
         Message: the commit message
         View the changeset: https://github.com/svenfuchs/minimal/compare/master...develop
-        View the full build log and details: https://travis-ci.org/svenfuchs/minimal/builds/#{build.id}
+        View the full build log and details: https://travis-ci.org/svenfuchs/minimal/builds/#{build.id}?utm_source=email&utm_medium=notification
       ))
     end
 
     it 'contains the expected html part' do
       email.html_part.body.should include_lines(%(
         Build #2 passed
+        https://travis-ci.org/svenfuchs/minimal?utm_source=email&amp;utm_medium=notification
         https://github.com/svenfuchs/minimal/compare/master...develop
-        https://travis-ci.org/svenfuchs/minimal/builds/#{build.id}
+        https://travis-ci.org/svenfuchs/minimal/builds/#{build.id}?utm_source=email&amp;utm_medium=notification
         62aae5f
         まつもとゆきひろ a.k.a. Matz
         the commit message

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Addons::GithubStatus::Task do
 
   let(:subject)    { Travis::Addons::GithubStatus::Task }
   let(:url)        { '/repos/svenfuchs/minimal/statuses/62aae5f70ceee39123ef' }
-  let(:target_url) { 'https://travis-ci.org/svenfuchs/minimal/builds/1' }
+  let(:target_url) { 'https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=github_status&utm_medium=notification' }
   let(:payload)    { Marshal.load(Marshal.dump(TASK_PAYLOAD)) }
   let(:io)         { StringIO.new }
 

--- a/spec/addons/hipchat/task_spec.rb
+++ b/spec/addons/hipchat/task_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Addons::Hipchat::Task do
     message = [
       'svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       'Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
-      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1'
+      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification'
     ]
 
     expect_hipchat('room_1', room_1_token, message)
@@ -55,7 +55,7 @@ describe Travis::Addons::Hipchat::Task do
     message = [
       'svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       'Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
-      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1'
+      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification'
     ]
 
     payload['build']['config']['notifications'] = { hipchat: { notify: true } }
@@ -69,7 +69,7 @@ describe Travis::Addons::Hipchat::Task do
   it "sends HTML notifications if requested" do
     targets = ["#{room_1_token}@room_1"]
     template = ['<a href="%{build_url}">Details</a>']
-    messages = ['<a href="https://travis-ci.org/svenfuchs/minimal/builds/1">Details</a>']
+    messages = ['<a href="https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification">Details</a>']
 
     payload['build']['config']['notifications'] = { hipchat: { template: template, format: 'html' } }
     expect_hipchat('room_1', room_1_token, messages, 'message_format' => 'html')
@@ -84,7 +84,7 @@ describe Travis::Addons::Hipchat::Task do
     messages = [
       'svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       'Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
-      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1'
+      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification'
     ]
 
     payload['build']['config']['notifications'] = { hipchat: [] }
@@ -99,7 +99,7 @@ describe Travis::Addons::Hipchat::Task do
     message = [
       'svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has passed',
       'Change view: https://github.com/svenfuchs/minimal/compare/master...develop',
-      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1'
+      'Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification'
     ]
 
     expect_hipchat('room_1', room_1_token, message, {}, 'hipchat.example.com')
@@ -114,7 +114,7 @@ describe Travis::Addons::Hipchat::Task do
     messages = [
       "svenfuchs/minimal#2 (master - 62aae5f : Sven Fuchs): the build has errored",
       "Change view: https://github.com/svenfuchs/minimal/compare/master...develop",
-      "Build details: https://travis-ci.org/svenfuchs/minimal/builds/1"
+      "Build details: https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=hipchat&utm_medium=notification"
     ]
 
     payload["build"]["state"] = "errored"

--- a/spec/addons/slack/task_spec.rb
+++ b/spec/addons/slack/task_spec.rb
@@ -22,8 +22,8 @@ describe Travis::Addons::Slack::Task do
       icon_url: "https://travis-ci.org/images/travis-mascot-150.png",
       channel: '#channel1',
       attachments: [{
-        fallback: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
-        text: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
+        fallback: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=slack&utm_medium=notification|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
+        text: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=slack&utm_medium=notification|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
         color: 'good'
       }.stringify_keys]
     }.stringify_keys
@@ -40,8 +40,8 @@ describe Travis::Addons::Slack::Task do
     message = {
       icon_url: "https://travis-ci.org/images/travis-mascot-150.png",
       attachments: [{
-        fallback: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
-        text: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
+        fallback: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=slack&utm_medium=notification|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
+        text: 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=slack&utm_medium=notification|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master by Sven Fuchs passed in 1 min 0 sec',
         color: 'good'
       }.stringify_keys]
     }.stringify_keys
@@ -54,7 +54,7 @@ describe Travis::Addons::Slack::Task do
 
   it "allows specifying a custom template" do
     targets = ['team-1:token-1']
-    payload['build']['config']['notifications'] = { slack: { template: 'Custom: %{author}'}} 
+    payload['build']['config']['notifications'] = { slack: { template: 'Custom: %{author}'}}
     message = {
       icon_url: "https://travis-ci.org/images/travis-mascot-150.png",
       attachments: [{
@@ -78,7 +78,7 @@ describe Travis::Addons::Slack::Task do
 
   it "supports a list as templates" do
     targets = ['team-1:token-1']
-    payload['build']['config']['notifications'] = { slack: { template: ['Custom: %{author}', 'More: %{branch}']}} 
+    payload['build']['config']['notifications'] = { slack: { template: ['Custom: %{author}', 'More: %{branch}']}}
     message = {
       icon_url: "https://travis-ci.org/images/travis-mascot-150.png",
       attachments: [{
@@ -98,7 +98,7 @@ describe Travis::Addons::Slack::Task do
     payload['build']['pull_request'] = true
     payload['build']['pull_request_number'] = '1'
 
-    expected_text = 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master in PR <https://github.com/svenfuchs/minimal/pull/1|#1> by Sven Fuchs passed in 1 min 0 sec'
+    expected_text = 'Build <https://travis-ci.org/svenfuchs/minimal/builds/1?utm_source=slack&utm_medium=notification|#2> (<https://github.com/svenfuchs/minimal/compare/master...develop|62aae5f>) of svenfuchs/minimal@master in PR <https://github.com/svenfuchs/minimal/pull/1|#1> by Sven Fuchs passed in 1 min 0 sec'
 
     message = {
       icon_url: "https://travis-ci.org/images/travis-mascot-150.png",


### PR DESCRIPTION
This adds `utm_source=[email|github_status|hipchat|slack]&utm_medium=notification` to inbound build urls