### PR TITLE
Publish notification data to keen.io

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--colour
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,17 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
-gem 'travis-support',  git: 'https://github.com/travis-ci/travis-support'
+gem 'travis-logger',     git: 'https://github.com/travis-ci/travis-logger'
+gem 'travis-exceptions', git: 'https://github.com/travis-ci/travis-exceptions'
 gem 'travis-config',   '~> 1.1.0'
+gem 'travis-metrics',  '~> 2.0.0.rc3'
 
 gem 'sidekiq',         '~> 4.0.0'
 gem 'redis-namespace'
 gem 'sentry-raven'
 gem 'metriks'
 gem 'metriks-librato_metrics'
+gem 'keen'
 
 gem 'jemalloc', git: 'https://github.com/joshk/jemalloc-rb'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,10 +5,17 @@ GIT
     jemalloc (1.4.5)
 
 GIT
-  remote: https://github.com/travis-ci/travis-support
-  revision: 113cff17fe383bb72fcfae3a97a8ce98c228342f
+  remote: https://github.com/travis-ci/travis-exceptions
+  revision: 71b11939f1f3b86d1e2fd94f3b9b8f78af290e12
   specs:
-    travis-support (0.0.1)
+    travis-exceptions (0.0.2)
+      sentry-raven
+
+GIT
+  remote: https://github.com/travis-ci/travis-logger
+  revision: b589e0ca0e9f1a5d6cd8536ff7288d21d36c7560
+  specs:
+    travis-logger (0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -85,6 +92,8 @@ GEM
     jmespath (1.1.3)
     journey (1.0.4)
     json (1.8.3)
+    keen (0.7.8)
+      multi_json (~> 1.0)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -174,6 +183,8 @@ GEM
     tilt (1.4.1)
     travis-config (1.1.2)
       hashr (~> 2.0.0)
+    travis-metrics (2.0.0)
+      metriks-librato_metrics (~> 1.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -192,6 +203,7 @@ DEPENDENCIES
   guard
   guard-rspec
   jemalloc!
+  keen
   metriks
   metriks-librato_metrics
   mocha (~> 0.10.0)
@@ -203,7 +215,9 @@ DEPENDENCIES
   sentry-raven
   sidekiq (~> 4.0.0)
   travis-config (~> 1.1.0)
-  travis-support!
+  travis-exceptions!
+  travis-logger!
+  travis-metrics (~> 2.0.0.rc3)
   webmock (~> 1.8.0)
 
 RUBY VERSION

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-tasks: bundle exec je sidekiq -c 25 -r ./lib/travis/tasks.rb -q notifications -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q webhook -q slack -q pushover
+tasks: bundle exec je sidekiq -c 25 -r ./lib/travis/tasks.rb -q notifications -q campfire -q email -q flowdock -q github_commit_status -q github_status -q hipchat -q irc -q webhook -q slack -q pushover -q tasks -q keenio

--- a/lib/core_ext/hash/compact.rb
+++ b/lib/core_ext/hash/compact.rb
@@ -1,0 +1,12 @@
+class Hash
+  def compact
+    dup.compact!
+  end
+
+  def compact!
+    keys.each do |key|
+      delete(key) if self[key].nil?
+    end
+    self
+  end
+end unless {}.respond_to?(:compact)

--- a/lib/core_ext/hash/deep_symbolize_keys.rb
+++ b/lib/core_ext/hash/deep_symbolize_keys.rb
@@ -1,0 +1,19 @@
+class Hash
+  def deep_symbolize_keys
+    inject({}) { |result, (key, value)|
+      result[(key.to_sym rescue key) || key] = case value
+      when Array
+        value.map { |value| value.is_a?(Hash) ? value.deep_symbolize_keys : value }
+      when Hash
+        value.deep_symbolize_keys
+      else
+        value
+      end
+      result
+    }
+  end unless Hash.method_defined?(:deep_symbolize_keys)
+
+  def deep_symbolize_keys!
+    replace(deep_symbolize_keys)
+  end unless Hash.method_defined?(:deep_symbolize_keys!)
+end

--- a/lib/core_ext/hash/slice.rb
+++ b/lib/core_ext/hash/slice.rb
@@ -1,0 +1,5 @@
+class Hash
+  def slice(*keys)
+    Hash[*keys.map { |key| [key, self[key]] if key?(key) }.compact.flatten]
+  end unless method_defined?(:slice)
+end

--- a/lib/core_ext/module/include.rb
+++ b/lib/core_ext/module/include.rb
@@ -1,0 +1,5 @@
+Class.class_eval do
+  def include(*args, &block)
+    block_given? ? super(Module.new(&block)) : super(*args)
+  end
+end

--- a/lib/core_ext/module/prepend_to.rb
+++ b/lib/core_ext/module/prepend_to.rb
@@ -1,0 +1,12 @@
+require 'core_ext/module/include'
+
+class Module
+  def prepend_to(name, &definition)
+    wrapped = instance_method(name)
+    remove_method(name) # to avoid warning
+
+    define_method(name) do |*args, &block|
+      definition.call(self, wrapped.bind(self), *args, &block)
+    end
+  end
+end

--- a/lib/travis/addons/email/mailer/build.rb
+++ b/lib/travis/addons/email/mailer/build.rb
@@ -46,7 +46,7 @@ module Travis
             end
 
             def subject_prefix
-              if build[:event_type] == 'cron'
+              if build[:type] == 'cron'
                 "[CRON] "
               else
                 ""

--- a/lib/travis/addons/webhook/payload.rb
+++ b/lib/travis/addons/webhook/payload.rb
@@ -1,0 +1,127 @@
+require 'travis/addons/util/result_message'
+
+module Travis
+  module Addons
+    module Webhook
+      class Payload < Struct.new(:payload)
+        def data
+          {
+            id:                  build[:id],
+            number:              build[:number],
+            config:              build[:config],
+            type:                build[:type],
+            state:               build[:state],
+            status:              result(build),
+            result:              result(build),
+            status_message:      result_message(build),
+            result_message:      result_message(build),
+            started_at:          build[:started_at],
+            finished_at:         build[:finished_at],
+            duration:            build[:duration],
+            build_url:           build_url,
+            commit_id:           commit[:id],
+            commit:              commit[:sha],
+            base_commit:         commit[:sha],
+            head_commit:         request[:head_commit],
+            branch:              commit[:branch],
+            message:             commit[:message],
+            compare_url:         commit[:compare_url],
+            committed_at:        commit[:committed_at],
+            author_name:         commit[:author_name],
+            author_email:        commit[:author_email],
+            committer_name:      commit[:committer_name],
+            committer_email:     commit[:committer_email],
+            pull_request:        pull_request[:number],
+            pull_request_number: pull_request[:number],
+            pull_request_title:  pull_request[:title],
+            tag:                 tag[:name],
+            repository:          repository_data,
+            matrix:              jobs.map { |job| job_data(job) }
+          }
+        end
+
+        def repository_data
+          {
+            id:         repo[:id],
+            name:       repo[:name],
+            owner_name: repo[:owner_name],
+            url:        repo[:url]
+          }
+        end
+
+        def job_data(job)
+          {
+            id:               job[:id],
+            repository_id:    repo[:id],
+            parent_id:        build[:id],
+            number:           job[:number],
+            state:            job[:state],
+            config:           job[:config],
+            status:           result(job),
+            result:           result(job),
+            commit:           commit[:sha],
+            branch:           commit[:branch],
+            message:          commit[:message],
+            compare_url:      commit[:compare_url],
+            started_at:       job[:started_at],
+            finished_at:      job[:finished_at],
+            committed_at:     commit[:committed_at],
+            author_name:      commit[:author_name],
+            author_email:     commit[:author_email],
+            committer_name:   commit[:committer_name],
+            committer_email:  commit[:committer_email],
+            allow_failure:    job[:allow_failure]
+          }
+        end
+
+        def build
+          payload[:build] || {}
+        end
+
+        def repo
+          payload[:repository] || {}
+        end
+
+        def request
+          payload[:request] || {}
+        end
+
+        def commit
+          payload[:commit] || {}
+        end
+
+        def pull_request
+          payload[:pull_request] || {}
+        end
+
+        def tag
+          payload[:tag] || {}
+        end
+
+        def jobs
+          payload[:jobs] || []
+        end
+
+        def result(obj)
+          case obj[:state].try(:to_sym)
+          when :passed then 0
+          when :failed, :errored then 1
+          else nil
+          end
+        end
+
+        def result_message(obj)
+          Util::ResultMessage.new(obj).short
+        end
+
+        def build_url
+          ["https://#{Travis.config[:host]}", repo[:slug], 'builds', build[:id]].join('/')
+        end
+
+        def format_date(date)
+          date && date.strftime('%Y-%m-%dT%H:%M:%SZ')
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/support.rb
+++ b/lib/travis/support.rb
@@ -1,0 +1,15 @@
+require 'travis/logger'
+require 'travis/support/exception_handling'
+require 'travis/support/logging'
+
+module Travis
+  class << self
+    def logger
+      @logger ||= Logger.configure(Logger.new(STDOUT), config)
+    end
+
+    def logger=(logger)
+      @logger = Logger.configure(logger, config)
+    end
+  end
+end

--- a/lib/travis/support/exception_handling.rb
+++ b/lib/travis/support/exception_handling.rb
@@ -1,0 +1,21 @@
+# TODO there's now Module.prepend, so we can use it.
+require 'core_ext/module/prepend_to'
+
+module Travis
+  module ExceptionHandling
+    def rescues(name, opts = {})
+      prepend_to(name) do |object, method, *args, &block|
+        if Travis.env == 'test'
+          method.call(*args, &block)
+        else
+          begin
+            method.call(*args, &block)
+          rescue opts[:from] || Exception => e
+            Travis::Exceptions.handle(e)
+            raise if opts[:raise] && Array(opts[:raise]).include?(e.class)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/support/logging.rb
+++ b/lib/travis/support/logging.rb
@@ -1,0 +1,90 @@
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/module/aliasing'
+require 'logger'
+
+module Travis
+  module Logging
+    class << self
+      def configure(*args, &block)
+        require 'travis/support/logger'
+        puts '[Deprecation] Travis::Logging.configure is deprecated. Use Travis::Logger.configure instead.'
+        Logger.configure(*args, &block)
+      end
+
+      def included(base)
+        base.extend(ClassMethods)
+      end
+
+      def wrap(type, name, args, options = {})
+        Travis.logger.send(type || :info, prepend_header("about to #{name}#{format_arguments(args)}", options)) unless options[:only] == :after
+        result = yield
+        Travis.logger.send(type || :debug, prepend_header("done: #{name}", options)) unless options[:only] == :before
+        result
+      end
+
+      def prepend_header(line, options = {})
+        options[:log_header] ?  "[#{options[:log_header]}] #{line}" : line
+      end
+
+      private
+
+        def format_arguments(args)
+          args.empty? ? '' : "(#{args.map { |arg| format_argument(arg).inspect }.join(', ')})"
+        end
+
+        def format_argument(arg)
+          if arg.is_a?(Hash) && arg.key?(:log) && arg[:log].size > 80
+            arg = arg.dup
+            arg[:log] = "#{arg[:log][0..80]} ..."
+          end
+          arg
+        end
+    end
+
+    module ClassMethods
+      def log_header(&block)
+        block ? @log_header = block : @log_header
+      end
+
+      def log(name, options = {})
+        define_method(:"#{name}_with_log") do |*args, &block|
+          options[:log_header] ||= self.log_header
+          Travis::Logging.wrap(options[:as], name, options[:params].is_a?(FalseClass) ? [] : args, options) do
+            send(:"#{name}_without_log", *args, &block)
+          end
+        end
+        alias_method_chain name, 'log'
+      end
+    end
+
+    delegate :logger, :to => Travis
+
+    [:fatal, :error, :warn, :info, :debug].each do |level|
+      define_method(level) do |*args|
+        message, options = *args
+        if logger.method(level).arity == -2
+          options ||= {}
+          options[:log_header] ||= self.log_header
+          logger.send(level, message, options)
+        else
+          logger.send(level, message)
+        end
+      end
+    end
+
+    def log_exception(exception)
+      message = "#{exception.class.name}: #{exception.message}\n"
+      message << exception.backtrace.join("\n") if exception.backtrace
+      error(message, log_header: log_header)
+    rescue Exception => e
+      puts '--- FATAL ---'
+      puts 'an exception occured while logging an exception'
+      puts e.message, e.backtrace
+      puts exception.message, exception.backtrace
+    end
+
+    def log_header
+      self.class.log_header ? instance_eval(&self.class.log_header) : self.class.name.split('::').last.downcase
+    end
+  end
+end

--- a/lib/travis/task/keenio.rb
+++ b/lib/travis/task/keenio.rb
@@ -1,0 +1,55 @@
+require 'keen'
+
+module Travis
+  class Task
+    class Keenio < Struct.new(:type, :status, :payload)
+      def publish(keen = Keen)
+        Keen.publish(:notifications, data)
+      end
+
+      def data
+        {
+          type:       type,
+          status:     status,
+          repository: repo_data,
+          owner:      owner_data,
+          build:      build_data
+        }
+      end
+
+      def repo_data
+        {
+          id:   repo[:id],
+          slug: repo[:slug]
+        }
+      end
+
+      def owner_data
+        {
+          id:    owner[:id],
+          type:  owner[:type],
+          login: owner[:login]
+        }
+      end
+
+      def build_data
+        {
+          id:    build[:id],
+          type:  build[:type]
+        }
+      end
+
+      def repo
+        payload[:repository] || {}
+      end
+
+      def owner
+        payload[:owner] || {}
+      end
+
+      def build
+        payload[:build] || {}
+      end
+    end
+  end
+end

--- a/lib/travis/tasks/config.rb
+++ b/lib/travis/tasks/config.rb
@@ -1,8 +1,14 @@
 require 'travis/config'
 
 module Travis
-  def self.config
-    @config ||= Tasks::Config.load
+  class << self
+    def config
+      @config ||= Tasks::Config.load
+    end
+
+    def env
+     ENV['ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+    end
   end
 
   module Tasks

--- a/lib/travis/tasks/worker.rb
+++ b/lib/travis/tasks/worker.rb
@@ -1,0 +1,29 @@
+module Travis
+  module Tasks
+    class Worker
+      include ::Sidekiq::Worker
+
+      attr_accessor :retry_count
+
+      def perform(_, target, method, payload, params = {})
+        const  = constantize(target)
+        params = params.merge(retry_count: retry_count.to_i)
+        const.send(method, payload, params)
+      end
+
+      private
+
+        def constantize(str)
+          str.split('::').inject(Kernel) do |const, name|
+            const.const_get(name)
+          end
+        end
+    end
+  end
+
+  module Async
+    module Sidekiq
+      Worker = Travis::Tasks::Worker
+    end
+  end
+end

--- a/lib/travis/testing/webmock.rb
+++ b/lib/travis/testing/webmock.rb
@@ -1,0 +1,81 @@
+require 'active_support'
+require 'webmock'
+require 'webmock/rspec'
+require 'uri'
+
+module Travis
+  module Support
+    module Testing
+      module Webmock
+        extend ActiveSupport::Concern
+
+        included do
+          before :each do
+            Travis::Support::Testing::Webmock.mock!
+            WebMock.disable_net_connect!
+          end
+        end
+
+        class MockRequest
+          attr_reader :uri, :stub
+
+          def initialize(url)
+            @uri = URI.parse(url)
+          end
+
+          def response
+            { :status => 200, :body => body, :headers => {} }
+          end
+
+          private
+
+            def body
+              store unless stored?
+              File.read(filename)
+            end
+
+            def store
+              puts "Storing #{uri.to_s} to #{filename}."
+              `curl -so #{filename} --create-dirs #{uri.to_s}`
+            end
+
+            def stored?
+              File.exists?(filename)
+            end
+
+            def filename
+              @filename ||= "spec/fixtures/github/#{escape(path)}"
+            end
+
+            def path
+              path = uri.path
+              path += "?#{uri.query}" if uri.query
+              "#{uri.host}#{path}.json"
+            end
+
+            def escape(path)
+              path.gsub(/[^\w\.\-\/]+/, '_')
+            end
+        end
+
+        class << self
+          attr_reader :requests
+
+          def mock!
+            @requests = {}
+            WebMock.stub_request(:get, %r(https?://(?!127.0.0.1|localhost))).to_return do |request|
+              uri = request.uri
+              request = MockRequest.new(uri)
+              @requests[uri] = request
+              request.response
+            end
+          end
+        end
+
+        def requests
+          Travis::Support::Testing::Webmock.requests
+        end
+      end
+    end
+  end
+end

--- a/spec/addons/email/mailer/build_spec.rb
+++ b/spec/addons/email/mailer/build_spec.rb
@@ -147,7 +147,7 @@ describe Travis::Addons::Email::Mailer::Build do
 
     describe 'for a cron build' do
       before :each do
-        data['build']['event_type'] = 'cron'
+        data['build']['type'] = 'cron'
       end
 
       it 'subject' do

--- a/spec/payloads.rb
+++ b/spec/payloads.rb
@@ -1,22 +1,36 @@
 TASK_PAYLOAD = {
+  "owner" => {
+    "id"=>1,
+    "type"=>"User",
+    "login"=>"login"
+  },
   "repository" => {
     "id"=>1,
     "key"=>"-----BEGIN PUBLIC KEY-----",
     "slug"=>"svenfuchs/minimal",
     "name"=>"minimal",
+    "owner_name"=>"svenfuchs",
     "owner_email"=>"svenfuchs@artweb-design.de",
-    "owner_avatar_url"=>nil
+    "owner_avatar_url"=>nil,
+    "url"=>"https://github.com/svenfuchs/minimal"
   },
   "request" => {
     "token"=>"token",
     "head_commit"=>"head-commit"
+  },
+  "pull_request" => {
+    "number"=>1,
+    "title"=>"title"
+  },
+  "tag" => {
+    "name"=>"v1.0.0"
   },
   "commit" => {
     "id"=>1,
     "sha"=>"62aae5f70ceee39123ef",
     "branch"=>"master",
     "message"=>"the commit message",
-    "committed _at"=>"2014-04-03T09:22:05Z",
+    "committed_at"=>"2014-04-03T09:22:05Z",
     "author_name"=>"Sven Fuchs",
     "author_email"=>"svenfuchs@artweb-design.de",
     "committer_name"=>"Sven Fuchs",
@@ -30,24 +44,32 @@ TASK_PAYLOAD = {
     "number"=>2,
     "pull_request"=>false,
     "config" => {
-      "rvm"=>["1.8.7", "1.9.2"],
-      "gemfile"=>["test/Gemfile.rails-2.3.x", "test/Gemfile.rails-3.0.x"]
+      "rvm"=>["1.8.7", "1.9.2"]
     },
     "state"=>"passed",
     "previous_state"=>"passed",
     "started_at"=>"2014-04-03T10:21:05Z",
     "finished_at"=>"2014-04-03T10:22:05Z",
     "duration"=>60,
-    "job_ids"=>[1, 2]
+    "job_ids"=>[1, 2],
+    "type"=>"push"
   },
   "jobs"=>[{
     "id"=>1,
     "number"=>"2.1",
-    "state"=>"passed"
+    "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.8.7"
+    },
+    "allow_failure"=>false
   }, {
     "id"=> 2,
     "number"=>"2.2",
     "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.9.2"
+    },
+    "allow_failure"=>false
   }]
 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,7 @@ end
 
 require 'travis/task'
 require 'travis/addons'
-require 'travis/support'
-require 'travis/support/testing/webmock'
+require 'travis/testing/webmock'
 require 'travis/testing'
 require 'travis/tasks/config'
 require 'payloads'

--- a/spec/task/keenio_spec.rb
+++ b/spec/task/keenio_spec.rb
@@ -1,0 +1,19 @@
+describe Travis::Task::Keenio do
+  let(:type)    { :email }
+  let(:status)  { :success }
+  let(:data)    { described_class.new(type, status, payload).data }
+  let(:payload) { Marshal.load(Marshal.dump(TASK_PAYLOAD)).deep_symbolize_keys }
+
+  it { expect(data[:type]).to              eq :email }
+  it { expect(data[:status]).to            eq :success }
+
+  it { expect(data[:repository][:id]).to   eq 1 }
+  it { expect(data[:repository][:slug]).to eq 'svenfuchs/minimal' }
+
+  it { expect(data[:owner][:id]).to        eq 1 }
+  it { expect(data[:owner][:type]).to      eq 'User' }
+  it { expect(data[:owner][:login]).to     eq 'login' }
+
+  it { expect(data[:build][:id]).to        eq 1 }
+  it { expect(data[:build][:type]).to      eq 'push' }
+end


### PR DESCRIPTION
In order to publish notification metrics to keen.io we need to:

* Have access to the Sidekiq `retry_count`. In order to do that we need to move the worker from `travis-support` to here. In order to do that I have removed `travis-support` entirely, and inlined the few bits that Tasks is currently using.

* Have a complete payload for all events, including webhooks. This change is moving the generation of the webhook payload from Hub to Tasks.

Related: https://github.com/travis-ci/travis-hub/pull/113