### PR TITLE
Add build id and repo slug to email log

### DIFF
--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -33,12 +33,17 @@ module Travis
 
           def send_email
             Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-            info "type=email build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
+            info "type=email repo= #{repository_slug(payload)} build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
           end
 
           def build_id(data)
             build = Hashr.new(data[:build])
             build.id
+          end
+
+          def repository_slug(data)
+            repository = @repository = Hashr.new(data[:repository])
+            repository.slug
           end
 
           def valid?(email)

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -33,7 +33,7 @@ module Travis
 
           def send_email
             Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-            puts "type=email build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
+            info "type=email build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
           end
 
           def build_id(data)

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -33,17 +33,21 @@ module Travis
 
           def send_email
             Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-            info "type=email repo= #{repository_slug(payload)} build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
+            info "type=email repo=#{repository_slug(payload)} build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
           end
 
           def build_id(data)
             build = Hashr.new(data[:build])
             build.id
+          rescue
+            "nil"
           end
 
           def repository_slug(data)
-            repository = @repository = Hashr.new(data[:repository])
+            repository = Hashr.new(data[:repository])
             repository.slug
+          rescue
+            "nil"
           end
 
           def valid?(email)

--- a/lib/travis/addons/email/task.rb
+++ b/lib/travis/addons/email/task.rb
@@ -33,7 +33,12 @@ module Travis
 
           def send_email
             Mailer::Build.finished_email(payload, recipients, broadcasts).deliver
-            info "type=email status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
+            puts "type=email build=#{build_id(payload)} status=sent msg='email sent' #{recipients.map { |r| 'email=' + obfuscate_email_address(r) }.join(' ')}"
+          end
+
+          def build_id(data)
+            build = Hashr.new(data[:build])
+            build.id
           end
 
           def valid?(email)


### PR DESCRIPTION
Adding the build id to the email log to make it easier to find to which e-mail(s) a notification was sent for a particular build.