### PR TITLE
Update trial email notifications

### DIFF
--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -36,14 +36,26 @@ module Travis
           private
 
             def from
-              config.email && config.email.from || "builds@#{config.host}"
+              "\"Travis CI\" <#{from_email}>"
             end
+
+            def from_email
+              config email && config.email.from || "builds@#{config.host}"
+            end
+
+            # def from
+            #   config.email && config.email.from || "Travis CI <builds@#{config.host}>"
+            # end
 
             def to
               config.email && config.email.trials_to_placeholder || "trials@#{config.host}"
             end
 
             def reply_to
+              "\"Travis CI Support\" <#{reply_to_email}>"
+            end
+
+            def reply_to_email
               config.email && config.email.reply_to || "support@#{config.host}"
             end
 

--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -36,11 +36,11 @@ module Travis
           private
 
             def from
-              "\"Travis CI\" <#{from_email}>"
+              "Travis CI <#{from_email}>"
             end
 
             def from_email
-              config email && config.email.from || "builds@#{config.host}"
+              config.email && config.email.from || "builds@#{config.host}"
             end
 
             # def from
@@ -52,7 +52,7 @@ module Travis
             end
 
             def reply_to
-              "\"Travis CI Support\" <#{reply_to_email}>"
+              "Travis CI Support <#{reply_to_email}>"
             end
 
             def reply_to_email

--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -30,7 +30,7 @@ module Travis
           def trial_ended(receivers, owner, builds_remaining)
             @owner = owner
             subject = "Your Travis CI trial just ended!"
-            mail(from: from, to: to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
+            mail(from: from, to: to, reply_to: reply_to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
           end
 
           private
@@ -41,6 +41,10 @@ module Travis
 
             def to
               config.email && config.email.trials_to_placeholder || "trials@#{config.host}"
+            end
+
+            def reply_to
+              config.email && config.email.reply_to || "support@#{config.host}"
             end
 
             def config

--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -12,19 +12,19 @@ module Travis
           def trial_started(receivers, owner, builds_remaining)
             @owner, @builds_remaining = owner, builds_remaining
             subject = "Welcome to your Travis CI trial!"
-            mail(from: from, to: to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
+            mail(from: from, to: to, reply_to: reply_to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
           end
 
           def trial_halfway(receivers, owner, builds_remaining)
             @owner, @builds_remaining = owner, builds_remaining
             subject = "Travis CI: Halfway through your trial"
-            mail(from: from, to: to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
+            mail(from: from, to: to, reply_to: reply_to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
           end
 
           def trial_about_to_end(receivers, owner, builds_remaining)
             @owner, @builds_remaining = owner, builds_remaining
             subject = "Travis CI: #{builds_remaining} builds left in your trial"
-            mail(from: from, to: to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
+            mail(from: from, to: to, reply_to: reply_to, bcc: filter_receivers(receivers), subject: subject, template_path: 'trial_mailer')
           end
 
           def trial_ended(receivers, owner, builds_remaining)

--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -43,10 +43,6 @@ module Travis
               config.email && config.email.from || "builds@#{config.host}"
             end
 
-            # def from
-            #   config.email && config.email.from || "Travis CI <builds@#{config.host}>"
-            # end
-
             def to
               config.email && config.email.trials_to_placeholder || "trials@#{config.host}"
             end


### PR DESCRIPTION
This adds a `reply_to` field and additional `Name` formatting to the trial build email notifications.
It has been deployed to com-staging and tested with a fake trial account there by @iriberri 

both keychains have also been updated