### PR TITLE
Switch to `travis-ci/branch` for GitHub status name

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -75,7 +75,7 @@ module Travis
           end
 
           def context
-            build_type = pull_request? ? "pr" : "push"
+            build_type = pull_request? ? "pr" : "branch"
             "continuous-integration/travis-ci/#{build_type}"
           end
 

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -19,31 +19,31 @@ describe Travis::Addons::GithubStatus::Task do
 
   it 'posts status info for a created build' do
     payload["build"]["state"] = 'created'
-    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
+    GH.expects(:post).with(url, state: 'pending', description: 'The Travis CI build is in progress', target_url: target_url, context: 'continuous-integration/travis-ci/branch').returns({})
     run
   end
 
   it 'posts status info for a passed build' do
     payload["build"]["state"] = 'passed'
-    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
+    GH.expects(:post).with(url, state: 'success', description: 'The Travis CI build passed', target_url: target_url, context: 'continuous-integration/travis-ci/branch').returns({})
     run
   end
 
   it 'posts status info for a failed build' do
     payload["build"]["state"] = 'failed'
-    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
+    GH.expects(:post).with(url, state: 'failure', description: 'The Travis CI build failed', target_url: target_url, context: 'continuous-integration/travis-ci/branch').returns({})
     run
   end
 
   it 'posts status info for a errored build' do
     payload['build']["state"] = 'errored'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/branch').returns({})
     run
   end
 
   it 'posts status info for a canceled build' do
     payload["build"]["state"] = 'canceled'
-    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/push').returns({})
+    GH.expects(:post).with(url, state: 'error', description: 'The Travis CI build could not complete due to an error', target_url: target_url, context: 'continuous-integration/travis-ci/branch').returns({})
     run
   end
 


### PR DESCRIPTION
To be consistent with our documentation