### PR TITLE
Display job name in GitHub "Check" Report if it exists

### DIFF
--- a/lib/travis/addons/github_check_status/output/stage.rb
+++ b/lib/travis/addons/github_check_status/output/stage.rb
@@ -61,10 +61,15 @@ module Travis::Addons::GithubCheckStatus::Output
       template(:allow_failure) if job[:allow_failure]
     end
 
+    def job_name(job)
+      return job[:name] unless job[:name].nil?
+      job[:number]
+    end
+    
     def table_data
       @table_data ||= jobs.map do |job|
         [
-          build_link(job[:state], job_url(job), job[:number]),
+          build_link(job[:state], job_url(job), job_name(job)),
           *matrix_attributes(job),
           state(job[:state]),
           notes(job)


### PR DESCRIPTION
Fixes #10028

Updated the table logic to check if a job name exists before defaulting to the default job number/id.

Regarding tests, how should they be handled? At the moment the `svenfuchs/minimal` repo doesn't have a job name that could be used in a test.