### PR TITLE
Reduce GitHub Checks API payload so that posting succeeds

### DIFF
--- a/lib/travis/addons/github_check_status/output/generator.rb
+++ b/lib/travis/addons/github_check_status/output/generator.rb
@@ -70,15 +70,6 @@ module Travis::Addons::GithubCheckStatus::Output
       finished_at if completed?
     end
 
-    def build_script_info
-      script = Array(build[:config][:script])
-      if script.any?
-        "Tests are run via the following build script:\n\n#{code(:bash, script.join("\n"))}"
-      else
-        "It's using the default test runner for #{language}."
-      end
-    end
-
     def language_info
       content = ""
       LANGUAGES.each do |key, description|

--- a/lib/travis/addons/github_check_status/output/generator.rb
+++ b/lib/travis/addons/github_check_status/output/generator.rb
@@ -88,6 +88,14 @@ module Travis::Addons::GithubCheckStatus::Output
       content.strip
     end
 
+    def config_display_text
+      if payload[:config_display_text]
+        payload[:config_display_text]
+      else
+        yaml(build[:config])
+      end
+    end
+
     def yaml(config)
       # config.deep_stringify_keys.to_yaml.sub(/^---\n/, '')
       JSON.pretty_generate(config)

--- a/lib/travis/addons/github_check_status/output/generator.rb
+++ b/lib/travis/addons/github_check_status/output/generator.rb
@@ -80,11 +80,7 @@ module Travis::Addons::GithubCheckStatus::Output
     end
 
     def config_display_text
-      if payload[:config_display_text]
-        payload[:config_display_text]
-      else
-        yaml(build[:config])
-      end
+      payload[:config_display_text] || yaml(build[:config])
     end
 
     def yaml(config)

--- a/lib/travis/addons/github_check_status/output/templates.rb
+++ b/lib/travis/addons/github_check_status/output/templates.rb
@@ -39,7 +39,7 @@ module Travis::Addons::GithubCheckStatus::Output
 
       <details>
       <summary>Build Configuration</summary>
-      {{config_display_text}}
+      {{code :yaml, config_display_text}}
       </details>
     MARKDOWN
 

--- a/lib/travis/addons/github_check_status/output/templates.rb
+++ b/lib/travis/addons/github_check_status/output/templates.rb
@@ -37,8 +37,6 @@ module Travis::Addons::GithubCheckStatus::Output
       Sudo Access      | {{build[:config][:sudo] ? 'required' : 'not required'}}
       {{language_info}}
 
-      {{build_script_info}}
-
       <details>
       <summary>Build Configuration</summary>
       {{config_display_text}}

--- a/lib/travis/addons/github_check_status/output/templates.rb
+++ b/lib/travis/addons/github_check_status/output/templates.rb
@@ -41,7 +41,7 @@ module Travis::Addons::GithubCheckStatus::Output
 
       <details>
       <summary>Build Configuration</summary>
-      {{code :yaml, yaml(build[:config])}}
+      {{config_display_text}}
       </details>
     MARKDOWN
 

--- a/lib/travis/addons/github_check_status/task.rb
+++ b/lib/travis/addons/github_check_status/task.rb
@@ -4,6 +4,8 @@ module Travis
   module Addons
     module GithubCheckStatus
       class Task < Travis::Task
+        GITHUB_CHECK_API_PAYLOAD_LIMIT = 65535
+
         private
 
         def process(timeout)
@@ -90,7 +92,12 @@ module Travis
         end
 
         def check_status_payload
-          @check_status_payload ||= Output::Generator.new(payload).to_h
+          return @check_status_payload if @check_status_payload
+          return_data = Output::Generator.new(payload).to_h
+          if return_data.to_json.size > GITHUB_CHECK_API_PAYLOAD_LIMIT
+            return_data = Output::Generator.new(payload.merge(config_display_text: "Build configuration is too large to display")).to_h
+          end
+          @check_status_payload = return_data
         end
       end
     end

--- a/lib/travis/addons/github_check_status/task.rb
+++ b/lib/travis/addons/github_check_status/task.rb
@@ -19,7 +19,7 @@ module Travis
             if check_run
               response = github_apps.patch_with_app(check_run_patch_url(check_run["id"]), check_status_payload.to_json)
             else
-              error("type=github_check_status repo=#{repository[:slug]} sha=#{sha} reason=check_runs_empty ")
+              error("type=github_check_status repo=#{repository[:slug]} sha=#{sha} reason=check_runs_empty check_status_payload=#{check_status_payload.to_json}")
               return
             end
           end

--- a/spec/addons/github_check_status/output_spec.rb
+++ b/spec/addons/github_check_status/output_spec.rb
@@ -42,9 +42,7 @@ describe Travis::Addons::GithubCheckStatus::Output do
       Operating System | Linux
       Sudo Access      | not required
       Ruby Versions    | 1.8.7, 1.9.2
-
-      It's using the default test runner for Ruby.
-
+      
       <details>
       <summary>Build Configuration</summary>
       <pre lang='yaml'>
@@ -97,8 +95,6 @@ describe Travis::Addons::GithubCheckStatus::Output do
       Operating System | Linux
       Sudo Access      | not required
       Ruby Version     | 1.8.7
-
-      It's using the default test runner for Ruby.
 
       <details>
       <summary>Build Configuration</summary>
@@ -185,8 +181,6 @@ describe Travis::Addons::GithubCheckStatus::Output do
       Operating System | Linux
       Sudo Access      | not required
       Ruby Versions    | 1.8.7, 1.9.2
-
-      It's using the default test runner for Ruby.
 
       <details>
       <summary>Build Configuration</summary>


### PR DESCRIPTION
It appears undocumented in https://developer.github.com/v3/checks/runs/, but if the payload is larger than 65535 characters, `POST` and `PATCH` requests fail.

```
{"message":"Invalid request.\n\nOnly 65535 characters are allowed; 67198 were supplied.","documentation_url":"https://developer.github.com/v3/checks/runs/#create-a-check-run"} 
```

This PR checks how big the JSON payload is, and reduces it if it is too large.

Cutting off the payload is probably (untested) a bad idea, because such a payload may be invalid JSON.