### PR TITLE
upgrade metriks to latest hdrhistogram

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'travis-metrics',    git: 'https://github.com/travis-ci/travis-metrics'
 gem 'travis-config',   '~> 1.1.0'
 gem 'travis-github_apps', git: 'https://github.com/travis-ci/travis-github_apps'
 
-gem 'metriks',                 git: 'https://github.com/travis-ci/metriks', branch: 'igor-hdrhistogram-upgrade'
+gem 'metriks',                 git: 'https://github.com/travis-ci/metriks'
 gem 'metriks-librato_metrics', git: 'https://github.com/travis-ci/metriks-librato_metrics'
 
 gem 'sidekiq',         '~> 4.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'travis-metrics',    git: 'https://github.com/travis-ci/travis-metrics'
 gem 'travis-config',   '~> 1.1.0'
 gem 'travis-github_apps', git: 'https://github.com/travis-ci/travis-github_apps'
 
-gem 'metriks',                 git: 'https://github.com/travis-ci/metriks'
+gem 'metriks',                 git: 'https://github.com/travis-ci/metriks', branch: 'igor-hdrhistogram-upgrade'
 gem 'metriks-librato_metrics', git: 'https://github.com/travis-ci/metriks-librato_metrics'
 
 gem 'sidekiq',         '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/metriks
-  revision: 0e69a0c2a058d2d70bed5fc1210f9590569a990e
-  branch: igor-hdrhistogram-upgrade
+  revision: af974af9851e9c6102dbd9affe09f7d12b35b7b8
   specs:
     metriks (0.9.9.8)
       HDRHistogram (= 0.1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/metriks
-  revision: a72bec9a66c4aa990ac71a307898554194d36d61
+  revision: 0e69a0c2a058d2d70bed5fc1210f9590569a990e
   branch: igor-hdrhistogram-upgrade
   specs:
     metriks (0.9.9.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,11 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/metriks
-  revision: 9b5a34fecebecc741417b25e43c340394aa6cc5e
+  revision: a72bec9a66c4aa990ac71a307898554194d36d61
+  branch: igor-hdrhistogram-upgrade
   specs:
     metriks (0.9.9.8)
-      HDRHistogram (~> 0.1.3)
+      HDRHistogram (= 0.1.8)
       atomic (~> 1.0)
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
@@ -55,7 +56,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    HDRHistogram (0.1.7)
+    HDRHistogram (0.1.8)
     actionmailer (5.2.1)
       actionpack (= 5.2.1)
       actionview (= 5.2.1)
@@ -855,4 +856,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.4
+   1.17.1


### PR DESCRIPTION
We recently upgraded the HDRHistogram dep which broke metrics, because the API changed (see also https://github.com/travis-ci/travis-logs/pull/202).

See also https://github.com/travis-ci/metriks/pull/1.