### PR TITLE
remove unused sudo key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 
 rvm: 2.4.2
 
-sudo: false
-
 services:
   - redis-server
 


### PR DESCRIPTION
Travis CI uses a single linux infrastructure https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration