### PR TITLE
Download and attach invoice PDF to email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'webmock',       '~> 1.8.0'
   gem 'guard'
   gem 'guard-rspec'
+  gem 'capybara'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,6 +682,14 @@ GEM
     aws-sigv4 (1.0.3)
     backports (3.11.4)
     builder (3.2.3)
+    capybara (3.27.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -782,6 +790,7 @@ GEM
     redis (3.3.5)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    regexp_parser (1.6.0)
     roadie (3.4.0)
       css_parser (~> 1.4)
       nokogiri (~> 1.5)
@@ -819,6 +828,8 @@ GEM
     webmock (1.8.11)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -826,6 +837,7 @@ PLATFORMS
 DEPENDENCIES
   actionmailer (>= 5.2.2.1)
   aws-sdk
+  capybara
   faraday
   faraday_middleware
   foreman

--- a/lib/travis/addons/billing/mailer/billing_mailer.rb
+++ b/lib/travis/addons/billing/mailer/billing_mailer.rb
@@ -41,7 +41,11 @@ module Travis
             class AttachmentNotFound < StandardError; end
 
             def download_attachment(url)
-              response = Faraday.get(url)
+              conn = Faraday.new do |c|
+                c.use FaradayMiddleware::FollowRedirects
+                c.adapter Faraday.default_adapter
+              end
+              response = conn.get(url)
               if response.status == 200 && match = response.headers['Content-Disposition'].match(%r{attachment;\s*filename=\"?([\w\.]+)\"?})
                 attachments[match[1]] = response.body
               else

--- a/lib/travis/addons/billing/mailer/billing_mailer.rb
+++ b/lib/travis/addons/billing/mailer/billing_mailer.rb
@@ -15,9 +15,9 @@ module Travis
             mail(from: travis_email, to: receivers, subject: subject, template_path: 'billing_mailer')
           end
 
-          def invoice_payment_succeeded(receivers, subscription, owner, charge, event, invoice, cc_last_digits)
-            @subscription, @owner, @invoice, @cc_last_digits = subscription, owner, invoice, cc_last_digits
-            subject = "Travis CI: Your Invoice"
+          def invoice_payment_succeeded(receivers, subscription, owner, _charge, _event, invoice, cc_last_digits)
+            @invoice = InvoicePresenter.new(subscription, owner, invoice, cc_last_digits)
+            subject = 'Travis CI: Your Invoice'
             download_attachment invoice.fetch(:pdf_url)
             mail(from: travis_email, to: receivers, subject: subject, template_path: 'billing_mailer')
           end
@@ -52,6 +52,85 @@ module Travis
                 raise AttachmentNotFound, "Couldn't get attachment from #{url}: Status #{response.status} Headers: #{response.headers.inspect}"
               end
             end
+
+          class InvoicePresenter
+            attr_reader :cc_last_digits
+
+            def initialize(subscription, owner, invoice, cc_last_digits)
+              @subscription = subscription
+              @owner = owner
+              @invoice = invoice
+              @cc_last_digits = cc_last_digits
+            end
+
+            def account_name
+              @owner.fetch(:name)
+            end
+
+            def account_login
+              @owner.fetch(:login)
+            end
+
+            def company
+              @subscription.fetch(:company)
+            end
+
+            def address
+              @subscription.fetch(:address)
+            end
+
+            def city
+              @subscription.fetch(:city)
+            end
+
+            def state
+              @subscription.fetch(:state)
+            end
+
+            def post_code
+              @subscription.fetch(:post_code)
+            end
+
+            def country
+              @subscription.fetch(:country)
+            end
+
+            def vat_id
+              @subscription.fetch(:vat_id)
+            end
+
+            def full_name
+              @subscription.values_at(:first_name, :last_name).compact.join(' ')
+            end
+
+            def amount_due
+              @invoice.fetch(:amount_due) / 100.0
+            end
+
+            def created_at
+              Time.parse(@invoice.fetch(:created_at))
+            end
+
+            def invoice_id
+              @invoice.fetch(:invoice_id)
+            end
+
+            def current_period_start
+              Time.at(@invoice.fetch(:current_period_start))
+            end
+
+            def current_period_end
+              Time.at(@invoice.fetch(:current_period_end))
+            end
+
+            def plan
+              @invoice.fetch(:plan)
+            end
+
+            def pdf_url
+              @invoice.fetch(:pdf_url)
+            end
+          end
         end
       end
     end

--- a/lib/travis/addons/billing/mailer/helpers.rb
+++ b/lib/travis/addons/billing/mailer/helpers.rb
@@ -31,11 +31,6 @@ module Travis
           def applied_balance(start_balance, end_balance)
             number_to_currency((start_balance.to_i - end_balance.to_i) / 100.0)
           end
-
-          def invoice_pdf_url(invoice)
-            pdf_id = Digest::SHA1.hexdigest(invoice[:stripe_id] + invoice[:invoice_id])
-            "https://billing.travis-ci.com/invoices/#{pdf_id}.pdf"
-          end
         end
       end
     end

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/invoice_payment_succeeded.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/invoice_payment_succeeded.html.erb
@@ -214,7 +214,7 @@
                     <td class="invoice-header-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;">
                       <h2 id="invoice-header" style="font-size: 42px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">Thank you.</h2>
                       <p style="margin: 0 0 10px 0;">
-                        We love our customers! Below is your Travis CI invoice for the account
+                        We love our customers! Attached is your Travis CI invoice for the account
                         <span class="blue-text" style="color: #0068ff;"><%= @owner[:name] %></span>.
                       </p>
                       <% unless Travis.env == "production" %>
@@ -234,65 +234,33 @@
                           <td class="invoice-address-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;width: 60%;vertical-align: top;">
                             <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Billed To:</label>
                             <address style="font-style: normal;">
-                              <div>
-                                <% if @subscription[:company].present? %>
-                                  <%= @subscription[:company] %>
-                                <% end %>
-                              </div>
+                              <div><%= @subscription[:company] %></div>
+
+                              <div><%= @subscription[:first_name] %> <%= @subscription[:last_name] %></div>
+
+                              <div><%= @subscription[:address] %></div>
 
                               <div>
-                                <% if @subscription[:first_name].present? %>
-                                  <%= @subscription[:first_name] %>
-                                <% end %>
-                                <% if @subscription[:last_name].present? %>
-                                  <%= @subscription[:last_name] %>
-                                <% end %>
+                                <span><%= @subscription[:city] %></span>
+                                <span><%= @subscription[:state] %></span>
+                                <span><%= @subscription[:post_code] %></span>
                               </div>
 
-                              <div>
-                                <% if @subscription[:address].present? %>
-                                  <%= @subscription[:address] %>
-                                <% end %>
-                              </div>
-
-                              <%# <div> %>
-                                <%# if @subscription[:city].present? %>
-                                  <%#= @subscription[:city] %>
-                                <%# end %>
-                              <%# </div> %>
-
-                              <div>
-                                <% %w(city state post_code).each do |attr| %>
-                                  <span>
-                                    <% if @subscription[attr.to_sym].present? %>
-                                      <%= @subscription[attr.to_sym] %>
-                                    <% end %>
-                                  </span>
-                                <% end %>
-                              </div>
-
-                              <% %w(country vat_id).each do |attr| %>
-                                <% if @subscription[attr.to_sym].present? %>
-                                  <div><%= @subscription[attr.to_sym] %></div>
-                                <% end %>
-                              <% end %>
+                              <div><%= @subscription[:country] %></div>
+                              <div><%= @subscription[:vat_id] %></div>
                             </address>
                           </td>
                           <!-- Total / Created Date -->
                           <td class="invoice-total-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;vertical-align: top;">
                             <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Total (In USD)</label>
                             <div class="total-large dark-grey-text" style="color: #676767;font-size: 29px;font-weight: 300;background-color: #f7f9fb;padding: 10px;margin: 3px 0;">
-                              <% if @invoice[:object][:amount_due].present? %>
-                                <%= number_to_currency(@invoice[:object][:amount_due] / 100.0) %>
-                              <% end %>
+                              <%= number_to_currency(@invoice[:object][:amount_due] / 100.0) %>
                             </div>
-                            <% if @invoice[:created_at].present? %>
-                              <p style="margin: 0 0 10px 0;">
-                                <time datetime="<%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>">
-                                  <%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>
-                                </time>
-                              </p>
-                            <% end %>
+                            <p style="margin: 0 0 10px 0;">
+                              <time datetime="<%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>">
+                                <%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>
+                              </time>
+                            </p>
                           </td>
                         </tr>
                       </table>
@@ -329,92 +297,28 @@
                       <span><%= @invoice[:plan] %></span>
                     </td>
                   </tr>
-                  <!-- Price -->
-                  <tr class="invoice-line">
-                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Price</label>
-                      <span><%= number_to_currency(@invoice[:amount] / 100.0) %></span>
-                    </td>
-                  </tr>
-
-                   <!-- Invoice items ( VAT etc )-->
-                  <% if invoice_items(@invoice[:object]).present? %>
-                    <% invoice_items(@invoice[:object]).each do |invoice_item| %>
-                      <tr class="invoice-line">
-                        <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                          <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;"><%= invoice_item["description"] %></label>
-                          <span><%= number_to_currency(invoice_item[:amount] / 100.0) %></span>
-                        </td>
-                      </tr>
-                    <% end -%>
-                  <% end -%>
-
-                  <!-- Discount -->
-                  <% if @invoice[:object][:discount].present? %>
-                    <tr class="invoice-line">
-                      <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                        <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Discount</label>
-                        <span>
-                          <% if @invoice[:object][:discount][:coupon][:percent_off] -%>
-                            -<%= @invoice[:object][:discount][:coupon][:percent_off] %>%
-                          <% else -%>
-                            -<%= number_to_currency(@invoice[:object][:discount][:coupon][:amount_off] / 100.0) %>
-                          <% end -%>
-                        </span>
-                      </td>
-                    </tr>
-                  <% end -%>
-
-                  <!-- Balance / Debit / Credit -->
-                  <% if (balance = @invoice[:object][:starting_balance].to_i) != 0 -%>
-                    <tr class="invoice-line">
-                      <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                        <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;"><%= balance > 0 ? "Debit" : "Credit" %></label>
-                        <span><%= applied_balance(balance, @invoice[:object][:ending_balance]) %></span>
-                      </td>
-                    </tr>
-                  <% end -%>
-
-                  <!-- Total -->
-                  <tr class="invoice-line">
-                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;">Total</label>
-                      <span><%= number_to_currency(@invoice[:object][:amount_due] / 100.0) %></span>
-                    </td>
-                  </tr>
-
-                  <!-- VAT required -->
-                  <% if @subscription[:vat_required] == true -%>
-                    <tr>
-                      <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;">
-                        <span>(VAT due to the recipient)</span>
-                      </td>
-                    </tr>
-                  <% end -%>
 
                   <tr>
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;"><hr style="border-style: solid;color: #e5e7e9;margin: 10px 0;"></td>
                   </tr>
 
                   <!-- Download and update -->
-                  <% if not @hide_pdf_notice -%>
-                    <tr>
-                      <td class="download-and-update" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;padding-top: 5px;">
-                        <p class="download-link-container" style="margin: 0 0 10px 0;">
-                          <a href="<%= invoice_pdf_url(@invoice) %>" class="download-icon-link" style="display: inline-block;vertical-align: middle;width: 17px;height: 17px;">
-                            <%= image_tag("#{Travis.config.s3.url}/download-icon-cropped.png", alt: 'download arrow') %>
-                          </a>
-                          <a href="<%= invoice_pdf_url(@invoice) %>" class="download-link" style="vertical-align: middle;color: #9da3a7;font-size: 12px;font-weight: 700;text-decoration: none;text-transform: uppercase;">
-                            <span>Download a PDF copy</span>
-                          </a>
-                        </p>
-                        <p class="update-link-container" style="margin: 0;">
-                          Need to change your billing address? Update it
-                          <a href="https://billing.travis-ci.com/subscriptions/<%= @owner[:login] %>" class="update-link" style="color: #333333;">here</a>.
-                        </p>
-                      </td>
-                    </tr>
-                  <% end -%>
+                  <tr>
+                    <td class="download-and-update" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;padding-top: 5px;">
+                      <p class="download-link-container" style="margin: 0 0 10px 0;">
+                        <a href="<%= @invoice[:pdf_url] %>" class="download-icon-link" style="display: inline-block;vertical-align: middle;width: 17px;height: 17px;">
+                          <%= image_tag("#{Travis.config.s3.url}/download-icon-cropped.png", alt: 'download arrow') %>
+                        </a>
+                        <a href="<%= @invoice[:pdf_url] %>" class="download-link" style="vertical-align: middle;color: #9da3a7;font-size: 12px;font-weight: 700;text-decoration: none;text-transform: uppercase;">
+                          <span>Download a PDF copy</span>
+                        </a>
+                      </p>
+                      <p class="update-link-container" style="margin: 0;">
+                        Need to change your billing address? Update it
+                        <a href="https://billing.travis-ci.com/subscriptions/<%= @owner[:login] %>" class="update-link" style="color: #333333;">here</a>.
+                      </p>
+                    </td>
+                  </tr>
                 </table>
 
                 <!-- Email Footer Section -->

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/invoice_payment_succeeded.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/invoice_payment_succeeded.html.erb
@@ -215,7 +215,7 @@
                       <h2 id="invoice-header" style="font-size: 42px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">Thank you.</h2>
                       <p style="margin: 0 0 10px 0;">
                         We love our customers! Attached is your Travis CI invoice for the account
-                        <span class="blue-text" style="color: #0068ff;"><%= @owner[:name] %></span>.
+                        <span class="blue-text" style="color: #0068ff;"><%= @invoice.account_name %></span>.
                       </p>
                       <% unless Travis.env == "production" %>
                         <p style="margin: 0 0 10px 0;">Test Email! Not a valid invoice!</p>
@@ -234,31 +234,31 @@
                           <td class="invoice-address-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;width: 60%;vertical-align: top;">
                             <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Billed To:</label>
                             <address style="font-style: normal;">
-                              <div><%= @subscription[:company] %></div>
+                              <div><%= @invoice.company %></div>
 
-                              <div><%= @subscription[:first_name] %> <%= @subscription[:last_name] %></div>
+                              <div><%= @invoice.full_name %></div>
 
-                              <div><%= @subscription[:address] %></div>
+                              <div><%= @invoice.address %></div>
 
                               <div>
-                                <span><%= @subscription[:city] %></span>
-                                <span><%= @subscription[:state] %></span>
-                                <span><%= @subscription[:post_code] %></span>
+                                <span><%= @invoice.city %></span>
+                                <span><%= @invoice.state %></span>
+                                <span><%= @invoice.post_code %></span>
                               </div>
 
-                              <div><%= @subscription[:country] %></div>
-                              <div><%= @subscription[:vat_id] %></div>
+                              <div><%= @invoice.country %></div>
+                              <div><%= @invoice.vat_id %></div>
                             </address>
                           </td>
                           <!-- Total / Created Date -->
                           <td class="invoice-total-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;vertical-align: top;">
                             <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Total (In USD)</label>
                             <div class="total-large dark-grey-text" style="color: #676767;font-size: 29px;font-weight: 300;background-color: #f7f9fb;padding: 10px;margin: 3px 0;">
-                              <%= number_to_currency(@invoice[:object][:amount_due] / 100.0) %>
+                              <%= number_to_currency(@invoice.amount_due) %>
                             </div>
                             <p style="margin: 0 0 10px 0;">
-                              <time datetime="<%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>">
-                                <%= l Time.parse(@invoice[:created_at]), format: '%B %e, %Y' %>
+                              <time datetime="<%= l @invoice.created_at, format: '%B %e, %Y' %>">
+                                <%= l @invoice.created_at, format: '%B %e, %Y' %>
                               </time>
                             </p>
                           </td>
@@ -269,7 +269,7 @@
                   <!-- Invoice ID -->
                   <tr>
                     <td class="invoice-id-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 5px;">
-                      <label class="label-black" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;">Invoice #<%= @invoice[:invoice_id] %></label>
+                      <label class="label-black" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;">Invoice #<%= @invoice.invoice_id %></label>
                     </td>
                   </tr>
                   <!-- Subscription Period -->
@@ -277,9 +277,9 @@
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
                       <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Subscription Period</label>
                       <span>
-                        <%= l Time.at(@invoice[:current_period_start]), format: :long -%>
+                        <%= l @invoice.current_period_start, format: :long -%>
                         &ndash;
-                        <%= l Time.at(@invoice[:current_period_end]), format: :long -%>
+                        <%= l @invoice.current_period_end, format: :long -%>
                       </span>
                     </td>
                   </tr>
@@ -287,14 +287,14 @@
                   <tr class="invoice-line">
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
                       <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
-                      <span>Paid with credit card ending in <%= @cc_last_digits -%></span>
+                      <span>Paid with credit card ending in <%= @invoice.cc_last_digits %></span>
                     </td>
                   </tr>
                   <!-- Plan -->
                   <tr class="invoice-line">
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
                       <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Plan</label>
-                      <span><%= @invoice[:plan] %></span>
+                      <span><%= @invoice.plan %></span>
                     </td>
                   </tr>
 
@@ -306,16 +306,16 @@
                   <tr>
                     <td class="download-and-update" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;padding-top: 5px;">
                       <p class="download-link-container" style="margin: 0 0 10px 0;">
-                        <a href="<%= @invoice[:pdf_url] %>" class="download-icon-link" style="display: inline-block;vertical-align: middle;width: 17px;height: 17px;">
+                        <a href="<%= @invoice.pdf_url %>" class="download-icon-link" style="display: inline-block;vertical-align: middle;width: 17px;height: 17px;">
                           <%= image_tag("#{Travis.config.s3.url}/download-icon-cropped.png", alt: 'download arrow') %>
                         </a>
-                        <a href="<%= @invoice[:pdf_url] %>" class="download-link" style="vertical-align: middle;color: #9da3a7;font-size: 12px;font-weight: 700;text-decoration: none;text-transform: uppercase;">
+                        <a href="<%= @invoice.pdf_url %>" class="download-link" style="vertical-align: middle;color: #9da3a7;font-size: 12px;font-weight: 700;text-decoration: none;text-transform: uppercase;">
                           <span>Download a PDF copy</span>
                         </a>
                       </p>
                       <p class="update-link-container" style="margin: 0;">
                         Need to change your billing address? Update it
-                        <a href="https://billing.travis-ci.com/subscriptions/<%= @owner[:login] %>" class="update-link" style="color: #333333;">here</a>.
+                        <a href="https://billing.travis-ci.com/subscriptions/<%= @invoice.account_login %>" class="update-link" style="color: #333333;">here</a>.
                       </p>
                     </td>
                   </tr>

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -8,14 +8,15 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
     let(:subscription) {{}}
     let(:owner) {{}}
     let(:invoice) {{ pdf_url: pdf_url, object: {amount_due: 999}, current_period_start: Time.now.to_i, current_period_end: Time.now.to_i, amount: 999, created_at: Time.now.to_s}}
-    let(:pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
+    let(:real_pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
+    let(:pdf_url) { real_pdf_url }
     let(:filename) { 'TP123.pdf' }
     let(:cc_last_digits) { '1234' }
     let(:charge) { nil}
     let(:event) { nil}
 
     before do
-      stub_request(:get, pdf_url).to_return(status: 200, body: "% PDF", headers: {'Content-Disposition' => "attachment; filename=\"#{filename}\""})
+      stub_request(:get, real_pdf_url).to_return(status: 200, body: "% PDF", headers: {'Content-Disposition' => "attachment; filename=\"#{filename}\""})
     end
 
     it 'contains the right data' do
@@ -30,6 +31,22 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
       expect(attachment.content_type).to start_with('application/pdf')
       expect(attachment.filename).to eq(filename)
       expect(attachment.body.raw_source).to start_with('% PDF')
+    end
+
+    context 'when the pdf url redirects' do
+      let(:pdf_url) { 'http://redirects.dev/'}
+
+      before do
+        stub_request(:get, pdf_url).to_return(status: 301, headers: { 'Location' => real_pdf_url})
+      end
+
+      it 'still works' do
+        expect(mail.attachments.size).to eq(1)
+
+        attachment = mail.attachments.first
+
+        expect(attachment.filename).to eq(filename)
+      end
     end
   end
 end

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Travis::Addons::Billing::Mailer::BillingMailer do
+  describe '#invoice_payment_succeeded' do
+    subject(:mail) { described_class.invoice_payment_succeeded(recipients, subscription, owner, charge, event, invoice, cc_last_digits) }
+
+    let(:recipients) { ['sergio@travis-ci.com'] }
+    let(:subscription) {{}}
+    let(:owner) {{}}
+    let(:invoice) {{ pdf_url: pdf_url, object: {amount_due: 999}, current_period_start: Time.now.to_i, current_period_end: Time.now.to_i, amount: 999, created_at: Time.now.to_s}}
+    let(:pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
+    let(:filename) { 'TP123.pdf' }
+    let(:cc_last_digits) { '1234' }
+    let(:charge) { nil}
+    let(:event) { nil}
+
+    before do
+      stub_request(:get, pdf_url).to_return(status: 200, body: "% PDF", headers: {'Content-Disposition' => "attachment; filename=\"#{filename}\""})
+    end
+
+    it 'contains the right data' do
+      expect(mail.to).to eq(recipients)
+      expect(mail.from).to eq(['success@travis-ci.com'])
+      expect(mail.subject).to eq('Travis CI: Your Invoice')
+
+      expect(mail.attachments.size).to eq(1)
+
+      attachment = mail.attachments.first
+
+      expect(attachment.content_type).to start_with('application/pdf')
+      expect(attachment.filename).to eq(filename)
+      expect(attachment.body.raw_source).to start_with('% PDF')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ ActionMailer::Base.delivery_method = :test
 
 require 'mocha'
 require 'gh'
+require 'capybara'
 
 include Mocha::API
 
@@ -88,6 +89,17 @@ RSpec::Matchers.define :have_message do |event, object|
   end
 
   def find_message
+  end
+end
+
+RSpec::Matchers.define :have_text_lines do |expected|
+  match do |actual|
+    regex = Regexp.new(expected.strip.gsub(/\s+/, '\s+'))
+    actual.has_text?(regex)
+  end
+
+  failure_message do |actual|
+    "Expected HTML to contain the text #{expected}"
   end
 end
 


### PR DESCRIPTION
Not done (we're missing the new template), but this is how I imagine the new invoice email would work. Instead of generating it for the email, it downloads the pdf from the billing app and adds it as an attachment. The invoice data would still be available in the template, so that we can summarize it.