### PR TITLE
When displaying ENV values in GitHub Checks, escape less

### DIFF
--- a/lib/travis/addons/github_check_status/output/stage.rb
+++ b/lib/travis/addons/github_check_status/output/stage.rb
@@ -53,6 +53,7 @@ module Travis::Addons::GithubCheckStatus::Output
       case key
       when :os      then os_description(job, value)
       when :gemfile then "<a href='#{file_link(value)}'>#{escape(value)}</a>"
+      when :env     then Rack::Utils.escape_html(value.first) # env is passed on here as a single-element array
       else escape(value)
       end
     end
@@ -64,7 +65,7 @@ module Travis::Addons::GithubCheckStatus::Output
     def job_display_text(job)
       job[:config].key?(:name) ? "#{job[:number]} #{job[:config][:name]}" : job[:number].to_s
     end
-    
+
     def table_data
       @table_data ||= jobs.map do |job|
         [

--- a/spec/addons/github_check_status/output_spec.rb
+++ b/spec/addons/github_check_status/output_spec.rb
@@ -41,7 +41,7 @@ describe Travis::Addons::GithubCheckStatus::Output do
       Language         | Ruby
       Operating System | Linux
       Ruby Versions    | 1.8.7, 1.9.2
-      
+
       <details>
       <summary>Build Configuration</summary>
       <pre lang='yaml'>
@@ -166,6 +166,63 @@ describe Travis::Addons::GithubCheckStatus::Output do
         <tr>
           <td><a href='https://travis-ci.org/svenfuchs/minimal/jobs/2'><img src='https://travis-ci.org/images/stroke-icons/icon-passed.png' height='11'> 2.2</a></td>
           <td>1.9.2</td>
+          <td>passed</td>
+        </tr>
+      </tbody>
+      </table>
+
+      ## Build Configuration
+
+      Build Option     | Setting
+      -----------------|--------------
+      Language         | Ruby
+      Operating System | Linux
+      Ruby Versions    | 1.8.7, 1.9.2
+
+      <details>
+      <summary>Build Configuration</summary>
+      <pre lang='yaml'>
+      {
+        "rvm": [
+          "1.8.7",
+          "1.9.2"
+        ]
+      }
+      </pre>
+      </details>
+    MARKDOWN
+
+    example { expect(subject[:output][:text]).to eq(text) }
+  end
+
+  describe 'build with env data' do
+    let(:payload) { TASK_PAYLOAD_WITH_ENVS.deep_symbolize_keys }
+    let(:text)    { <<-MARKDOWN.gsub(/^      /, '').strip }
+      This is a normal build for the master branch. You should be able to reproduce it by checking out the branch locally.
+
+      ## Jobs and Stages
+      This build has **two jobs**, running in parallel.
+
+      <table>
+      <thead>
+        <tr>
+          <th>Job</th>
+          <th>Ruby</th>
+          <th>ENV</th>
+          <th>State</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href='https://travis-ci.org/svenfuchs/minimal/jobs/1'><img src='https://travis-ci.org/images/stroke-icons/icon-passed.png' height='11'> 2.1</a></td>
+          <td>1.8.7</td>
+          <td>[secure]</td>
+          <td>passed</td>
+        </tr>
+        <tr>
+          <td><a href='https://travis-ci.org/svenfuchs/minimal/jobs/2'><img src='https://travis-ci.org/images/stroke-icons/icon-passed.png' height='11'> 2.2</a></td>
+          <td>1.9.2</td>
+          <td>x=y</td>
           <td>passed</td>
         </tr>
       </tbody>

--- a/spec/payloads.rb
+++ b/spec/payloads.rb
@@ -170,3 +170,25 @@ TASK_PAYLOAD_WITH_STAGES = TASK_PAYLOAD.merge({
     "allow_failure"=>false
   }]
 })
+
+TASK_PAYLOAD_WITH_ENVS = TASK_PAYLOAD.merge({
+  "jobs"=>[{
+    "id"=>1,
+    "number"=>"2.1",
+    "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.8.7",
+      "env" => ["[secure]"]
+    },
+    "allow_failure"=>false
+  }, {
+    "id"=> 2,
+    "number"=>"2.2",
+    "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.9.2",
+      "env" => ["x=y"]
+    },
+    "allow_failure"=>false
+  }]
+})


### PR DESCRIPTION
Before (current production) https://github.com/BanzaiMan/travis-test/runs/213288267
After (with this PR) https://github.com/BanzaiMan/travis-test/runs/213288248

Resolves https://travis-ci.community/t/bug-environment-variables-display-is-overly-escaped-on-the-github-checks-page/1958