### PR TITLE
Shrink Gh check status size if it's still too large

### DIFF
--- a/lib/travis/addons/github_check_status/output/generator.rb
+++ b/lib/travis/addons/github_check_status/output/generator.rb
@@ -3,7 +3,7 @@ module Travis::Addons::GithubCheckStatus::Output
     FIELDS             = %i[ name head_sha details_url external_id status conclusion started_at completed_at ]
     OUTPUT_FIELDS      = %i[ title summary text annotations images ]
     include Helpers
-    attr_reader :payload, :build_info, :job_info
+    attr_reader :payload, :build_info
 
     def initialize(payload)
       @payload    = payload
@@ -81,6 +81,10 @@ module Travis::Addons::GithubCheckStatus::Output
 
     def config_display_text
       payload[:config_display_text] || yaml(build[:config])
+    end
+
+    def job_info_text
+      payload[:job_info_text] || @job_info.description
     end
 
     def yaml(config)

--- a/lib/travis/addons/github_check_status/output/templates.rb
+++ b/lib/travis/addons/github_check_status/output/templates.rb
@@ -26,7 +26,7 @@ module Travis::Addons::GithubCheckStatus::Output
       {{build_info.description}}
 
       ## Jobs and Stages
-      {{job_info.description}}
+      {{job_info_text}}
 
       ## Build Configuration
 

--- a/lib/travis/addons/github_check_status/task.rb
+++ b/lib/travis/addons/github_check_status/task.rb
@@ -96,6 +96,9 @@ module Travis
           return_data = Output::Generator.new(payload).to_h
           if return_data.to_json.size > GITHUB_CHECK_API_PAYLOAD_LIMIT
             return_data = Output::Generator.new(payload.merge(config_display_text: "Build configuration is too large to display")).to_h
+            if return_data.to_json.size > GITHUB_CHECK_API_PAYLOAD_LIMIT
+              return_data = Output::Generator.new(payload.merge(config_display_text: "Build configuration is too large to display", job_info_text: "Jobs information is too large to display")).to_h
+            end
           end
           @check_status_payload = return_data
         end


### PR DESCRIPTION
When a build has a big number of jobs it may still generate a payload
that is too big for GitHub. In this case we need to also strip jobs
info, not only build's config info, from the request.