### PR TITLE
Checks filter from github api changed from latest to all

### DIFF
--- a/lib/travis/addons/github_check_status/task.rb
+++ b/lib/travis/addons/github_check_status/task.rb
@@ -47,7 +47,7 @@ module Travis
         end
 
         def check_runs(ref)
-          path = "/repositories/#{repository[:github_id]}/commits/#{ref}/check-runs?check_name=#{URI.encode check_run_name}&filter=latest"
+          path = "/repositories/#{repository[:github_id]}/commits/#{ref}/check-runs?check_name=#{URI.encode check_run_name}&filter=all"
 
           response = github_apps.get_with_app(path)
 

--- a/spec/addons/github_check_status/task_spec.rb
+++ b/spec/addons/github_check_status/task_spec.rb
@@ -21,7 +21,7 @@ describe Travis::Addons::GithubCheckStatus::Task do
       builder.adapter :test do |stub|
         stub.post("app/installations/12345/access_tokens") { |env| [201, {}, "{\"token\":\"github_apps_access_token\",\"expires_at\":\"2018-04-03T20:52:14Z\"}"] }
         stub.post("/repositories/549743/check-runs") { |env| [201, {}, check_run_response(response_data)] }
-        stub.get("/repositories/549743/commits/#{sha}/check-runs?check_name=Travis+CI+-+Branch&filter=latest") { |env| [200, {}, check_run_list_response(response_data)] }
+        stub.get("/repositories/549743/commits/#{sha}/check-runs?check_name=Travis+CI+-+Branch&filter=all") { |env| [200, {}, check_run_list_response(response_data)] }
         stub.patch("/repositories/549743/check-runs/1") { |env| [200, {}, check_run_response(response_data)] }
       end
     end
@@ -44,7 +44,7 @@ describe Travis::Addons::GithubCheckStatus::Task do
         builder.adapter :test do |stub|
           stub.post("app/installations/12345/access_tokens") { |env| [201, {}, "{\"token\":\"github_apps_access_token\",\"expires_at\":\"2018-04-03T20:52:14Z\"}"] }
           stub.post("/repositories/549743/check-runs") { |env| [201, {}, check_run_response(response_data)] }
-          stub.get("/repositories/549743/commits/#{sha}/check-runs?check_name=Travis+CI+-+Branch&filter=latest") { |env| [403, {}, check_run_list_response(response_data)] }
+          stub.get("/repositories/549743/commits/#{sha}/check-runs?check_name=Travis+CI+-+Branch&filter=all") { |env| [403, {}, check_run_list_response(response_data)] }
           stub.patch("/repositories/549743/check-runs/1") { |env| [200, {}, check_run_response(response_data)] }
         end
       end


### PR DESCRIPTION
It's possible that we don't get enough checks info from GitHub using `filter=latests` and we don't receive checks we matter. I changed URL to receive all checks (`filter=all`) and then we filter important check anyway.