### PR TITLE
Converting a string to a time

### DIFF
--- a/lib/travis/addons/billing/mailer/views/billing_mailer/subscription_cancelled.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/subscription_cancelled.html.erb
@@ -150,7 +150,7 @@
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;">
                       <p style="font-size: 16px;margin: 0 0 10px 0;">
                         This email is to confirm your subscription with Travis CI has been cancelled and is set to expire on
-                        <span id="subscription-expiration" style="color: #e23a3c;"><%= @subscription[:valid_to].strftime("%B %d, %Y") %></span>.
+                        <span id="subscription-expiration" style="color: #e23a3c;"><%= Time.parse(@subscription[:valid_to]).strftime("%B %d, %Y") %></span>.
                       </p>
                       <p style="font-size: 16px;margin: 0 0 10px 0;">
                         If you cancelled by mistake, please respond to this email, and we&rsquo;ll help you get back in and running.


### PR DESCRIPTION
When a subscription is cancelled the `valid_to` is a string which was causing the following error

> undefined method `strftime' for "2019-11-09 04:40:36 UTC":String

It needs to be converted into a `Time`