### PR TITLE
Credit note (refund invoice) email template

### DIFF
--- a/lib/travis/addons/billing/mailer/billing_mailer.rb
+++ b/lib/travis/addons/billing/mailer/billing_mailer.rb
@@ -118,6 +118,10 @@ module Travis
               @invoice.fetch(:amount_due) / 100.0
             end
 
+            def amount_paid
+              @invoice.fetch(:amount_paid) / 100.0
+            end
+
             def amount_refunded
               @invoice.fetch(:amount_refunded) / 100.0
             end

--- a/lib/travis/addons/billing/mailer/billing_mailer.rb
+++ b/lib/travis/addons/billing/mailer/billing_mailer.rb
@@ -28,6 +28,13 @@ module Travis
             mail(from: cancellation_email, to: receivers, subject: subject, template_path: 'billing_mailer')
           end
 
+          def credit_note_raised(receivers, subscription, owner, _charge, _event, invoice, cc_last_digits)
+            @invoice = InvoicePresenter.new(subscription, owner, invoice, cc_last_digits)
+            subject = 'Travis CI: Your Payment has been refunded'
+            download_attachment invoice.fetch(:pdf_url)
+            mail(from: travis_email, to: receivers, subject: subject, template_path: 'billing_mailer')
+          end
+
           private
 
             def travis_email
@@ -109,6 +116,10 @@ module Travis
 
             def amount_due
               @invoice.fetch(:amount_due) / 100.0
+            end
+
+            def amount_refunded
+              @invoice.fetch(:amount_refunded) / 100.0
             end
 
             def created_at

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style type="text/css" media="screen">
+      /* Base */
+      body {
+        min-width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      body, td {
+        font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 16px;
+      }
+
+      hr {
+        border-style: solid;
+        color: #e5e7e9;
+        margin: 10px 0;
+      }
+
+      label {
+        display: block;
+        font-weight: 700;
+        font-size: 14px;
+        text-transform: uppercase;
+      }
+
+      address {
+        font-style: normal;
+      }
+
+      /* Outer layout */
+      #travis-ci-email-container {
+        height: 100%;
+        width: 100%;
+        padding: 30px;
+        font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        text-align: center;
+        color: #333333;
+        line-height: 1.4;
+        background-color: #f6f7fa;
+      }
+
+      #email-central-container {
+        font-family: inherit;
+        width: 500px;
+      }
+
+      /* Content */
+      #email-content-container {
+        padding: 6% 7% 5% 7%;
+        background-color: #FFFFFF;
+        width: 100%;
+      }
+
+      #email-content-container p {
+        margin: 0 0 10px 0;
+      }
+
+      /* Header area */
+      .invoice-header-container {
+        text-align: center;
+      }
+
+      /* #email-content-container .invoice-header-container p {
+        margin: 10px 0 0 0;
+      } */
+
+      #invoice-header {
+        font-size: 42px;
+        font-weight: 600;
+        margin: 1.136% 0 3.409% 0;
+        color: #0068ff;
+      }
+
+      /* Main Area */
+
+      .blue-text {
+        color: #0068ff;
+      }
+
+      .dark-grey-text {
+        color: #676767;
+      }
+
+      .invoice-address-and-total {
+        width: 100%;
+        margin:10px 0 20px 0;
+      }
+
+      .invoice-address-and-total td {
+        vertical-align: top;
+      }
+
+      .invoice-address-container {
+        width: 60%;
+      }
+
+      .total-large {
+        font-size: 29px;
+        font-weight: 300;
+        background-color: #f7f9fb;
+        padding: 10px;
+        margin: 3px 0;
+      }
+
+      .invoice-id-container {
+        padding-bottom: 5px;
+      }
+
+      .invoice-line td {
+        padding-bottom: 10px;
+      }
+
+      /* Download / Update area */
+      .download-and-update {
+        text-align: center;
+        padding-top: 5px;
+      }
+
+      #email-content-container p.update-link-container {
+        margin: 0;
+      }
+
+      .download-icon-link {
+        display: inline-block;
+        vertical-align: middle;
+        width: 40px;
+        height: 40px;
+        width: 17px;
+        height: 17px;
+        line-height: 17px;
+      }
+
+      .download-icon-link img {
+        width: 100%;
+      }
+
+      .download-and-update a.download-link {
+        vertical-align: middle;
+        color: #9da3a7;
+        font-size: 12px;
+        font-weight: 700;
+        text-decoration: none;
+        text-transform: uppercase;
+      }
+
+      .download-and-update a.update-link {
+        color: #333333;
+      }
+
+      /* Footer area */
+      #travis-ci-email-footer-container {
+        padding: 10% 7% 0% 7%;
+      }
+
+      #questions-section {
+        font-size: 18px;
+        color: #0068ff;
+        padding-bottom: 10.227%;
+      }
+
+      #questions-section a {
+        color: #0068ff;
+      }
+
+      #travis-ci-footer-logo-section {
+        padding-bottom: 6.818%;
+        text-align: center;
+      }
+
+      #email-footer-section {
+        font-size: 11px;
+        color: #9EA3A8;
+        text-align: center;
+        padding-top: 0px;
+        margin: 0px;
+      }
+
+      #email-footer-section a {
+        color: #9ea3a8;
+      }
+
+      #email-footer-section p {
+        margin: 0px;
+      }
+
+      #email-footer-section #payment-processor-message {
+        margin-bottom: 3.409%;
+        padding: 0 1%;
+      }
+    </style>
+  </head>
+
+  <body style="min-width: 100%;height: 100%;margin: 0;padding: 0;font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;">
+
+    <table id="travis-ci-email-container" align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" style="height: 100%;width: 100%;padding: 30px;font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;text-align: center;color: #333333;line-height: 1.4;background-color: #f6f7fa;">
+      <!-- Main Content Section -->
+      <tr>
+        <td align="center" valign="top" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;">
+          <table id="email-central-container" border="0" cellpadding="0" cellspacing="0" style="font-family: inherit;width: 500px;">
+            <tr>
+              <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;">
+                <table id="email-content-container" border="0" cellpadding="0" cellspacing="0" style="padding: 6% 7% 5% 7%;background-color: #FFFFFF;width: 100%;">
+                  <!-- Header - Thanks -->
+                  <tr>
+                    <td class="invoice-header-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;">
+                      <h2 id="invoice-header" style="font-size: 42px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">Thank you.</h2>
+                      <p style="margin: 0 0 10px 0;">
+                        We love our customers! Attached is your Travis CI refund for the account
+                        <span class="blue-text" style="color: #0068ff;"><%= @invoice.account_name %></span>.
+                      </p>
+                      <% unless Travis.env == "production" %>
+                        <p style="margin: 0 0 10px 0;">Test Email! Not a valid invoice!</p>
+                      <% end -%>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;"><hr style="border-style: solid;color: #e5e7e9;margin: 10px 0;"></td>
+                  </tr>
+                  <!-- Main Invoice Content -->
+                  <tr>
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;">
+                      <table class="invoice-address-and-total" style="width: 100%;margin: 10px 0 20px 0;">
+                        <tr>
+                          <!-- Address -->
+                          <td class="invoice-address-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;width: 60%;vertical-align: top;">
+                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Billed To:</label>
+                            <address style="font-style: normal;">
+                              <div><%= @invoice.company %></div>
+
+                              <div><%= @invoice.full_name %></div>
+
+                              <div><%= @invoice.address %></div>
+
+                              <div>
+                                <span><%= @invoice.city %></span>
+                                <span><%= @invoice.state %></span>
+                                <span><%= @invoice.post_code %></span>
+                              </div>
+
+                              <div><%= @invoice.country %></div>
+                              <div><%= @invoice.vat_id %></div>
+                            </address>
+                          </td>
+                          <!-- Total / Created Date -->
+                          <td class="invoice-total-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;vertical-align: top;">
+                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Total (In USD)</label>
+                            <div class="total-large dark-grey-text" style="color: #676767;font-size: 29px;font-weight: 300;background-color: #f7f9fb;padding: 10px;margin: 3px 0;">
+                              <%= number_to_currency(@invoice.amount_refunded) %>
+                            </div>
+                            <p style="margin: 0 0 10px 0;">
+                              <time datetime="<%= l @invoice.created_at, format: '%B %e, %Y' %>">
+                                <%= l @invoice.created_at, format: '%B %e, %Y' %>
+                              </time>
+                            </p>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <!-- Invoice ID -->
+                  <tr>
+                    <td class="invoice-id-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 5px;">
+                      <label class="label-black" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;">Invoice #<%= @invoice.invoice_id %></label>
+                    </td>
+                  </tr>
+                  <!-- Subscription Period -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Subscription Period</label>
+                      <span>
+                        <%#= l @invoice.current_period_start, format: :long -%>
+                        &ndash;
+                        <%#= l @invoice.current_period_end, format: :long -%>
+                      </span>
+                    </td>
+                  </tr>
+                  <!-- Status -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
+                      <span>Paid with credit card ending in <%= @invoice.cc_last_digits %></span>
+                    </td>
+                  </tr>
+                  <!-- Plan -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Plan</label>
+                      <span><%= @invoice.plan %></span>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;"><hr style="border-style: solid;color: #e5e7e9;margin: 10px 0;"></td>
+                  </tr>
+
+                  <!-- Download and update -->
+                  <tr>
+                    <td class="download-and-update" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;padding-top: 5px;">
+                      <p class="download-link-container" style="margin: 0 0 10px 0;">
+                        <a href="<%= @invoice.pdf_url %>" class="download-icon-link" style="display: inline-block;vertical-align: middle;width: 17px;height: 17px;">
+                          <%= image_tag("#{Travis.config.s3.url}/download-icon-cropped.png", alt: 'download arrow') %>
+                        </a>
+                        <a href="<%= @invoice.pdf_url %>" class="download-link" style="vertical-align: middle;color: #9da3a7;font-size: 12px;font-weight: 700;text-decoration: none;text-transform: uppercase;">
+                          <span>Download a PDF copy</span>
+                        </a>
+                      </p>
+                      <p class="update-link-container" style="margin: 0;">
+                        Need to change your billing address? Update it
+                        <a href="https://billing.travis-ci.com/subscriptions/<%= @invoice.account_login %>" class="update-link" style="color: #333333;">here</a>.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+
+                <!-- Email Footer Section -->
+                <table id="travis-ci-email-footer-container" border="0" cellpadding="0" cellspacing="0" style="padding: 10% 7% 0% 7%;">
+                  <tr>
+                    <td id="questions-section" align="center" valign="top" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 18px;color: #0068ff;padding-bottom: 10.227%;">
+                      <span>Have any questions?</span>
+                      <span>
+                        <a href="mailto:support@travis-ci.com" style="color: #0068ff;">We&rsquo;re here to help.</a>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td id="travis-ci-footer-logo-section" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 6.818%;text-align: center;">
+                      <%= link_to(image_tag("#{Travis.config.s3.url}/TravisCI-Logo-BW.png", alt: 'black and white travis ci logo'), 'https://travis-ci.com')%>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td id="email-footer-section" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 11px;color: #9EA3A8;text-align: center;padding-top: 0px;margin: 0px;">
+                      <p id="payment-processor-message" style="margin: 0px;margin-bottom: 3.409%;padding: 0 1%;">
+                        We use <a href="https://stripe.com" style="color: #9ea3a8;">Stripe Inc.</a>, 3180 18th Street, Suite 100, San Francisco, CA 94110, USA, as our payment partner
+                      </p>
+                      <p style="margin: 0px;">
+                        Travis CI GmbH, Rigaer Str. 8, 10427 Berlin, Germany | GF/CEO: Randy Jacops |
+                        <span>Contact: <%= link_to('contact@travis-ci.com', 'mailto:contact@travis-ci.com', style: 'color: #9EA3A8')%> | Amtsgericht Charlottenburg, Berlin, HRB 140133 B | Umsatzsteuer-ID gemäß §27 a Umsatzsteuergesetz: DE282002648</span>
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
@@ -214,7 +214,7 @@
                     <td class="invoice-header-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;">
                       <h2 id="invoice-header" style="font-size: 30px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">We are sorry to see you go :(</h2>
                       <p style="margin: 0 0 10px 0;">
-                        Your plan has been cancelled. We reimbursed your paid amount according to Travis CI refund policy. Attached is your refund invoice for account
+                        Your plan has been cancelled. We reimbursed your paid amount according to the Travis CI refund policy. Attached is your refund invoice for account
                         <span class="blue-text" style="color: #0068ff;"><%= @invoice.account_name %></span>.
                       </p>
                       <% unless Travis.env == "production" %>
@@ -284,22 +284,22 @@
                   <!-- Amount paid -->
                   <tr class="invoice-line">
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
-                      <span>Amount paid <%= @invoice.amount_refunded %></span>
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Amount paid</label>
+                      <span><%= number_to_currency(@invoice.amount_paid) %></span>
                     </td>
                   </tr>
                   <!-- Amount paid -->
                   <tr class="invoice-line">
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
-                      <span>Amount reimbursed <%= @invoice.amount_refunded %></span>
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Amount reimbursed</label>
+                      <span> <%= number_to_currency(@invoice.amount_refunded) %></span>
                     </td>
                   </tr>
                   <!-- Total -->
                   <tr class="invoice-line">
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
-                      <span>Total <%= @invoice.amount_refunded %></span>
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Total</label>
+                      <span>Total <%= number_to_currency(@invoice.amount_refunded) %></span>
                     </td>
                   </tr>
                   <tr>

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
@@ -212,9 +212,9 @@
                   <!-- Header - Thanks -->
                   <tr>
                     <td class="invoice-header-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;">
-                      <h2 id="invoice-header" style="font-size: 42px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">Thank you.</h2>
+                      <h2 id="invoice-header" style="font-size: 30px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">We are sorry to see you go :(</h2>
                       <p style="margin: 0 0 10px 0;">
-                        We love our customers! Attached is your Travis CI refund for the account
+                        Your plan has been cancelled. We reimbursed your paid amount according to Travis CI refund policy. Attached is your refund invoice for account
                         <span class="blue-text" style="color: #0068ff;"><%= @invoice.account_name %></span>.
                       </p>
                       <% unless Travis.env == "production" %>
@@ -232,7 +232,7 @@
                         <tr>
                           <!-- Address -->
                           <td class="invoice-address-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;width: 60%;vertical-align: top;">
-                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Billed To:</label>
+                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Issued To:</label>
                             <address style="font-style: normal;">
                               <div><%= @invoice.company %></div>
 
@@ -252,15 +252,10 @@
                           </td>
                           <!-- Total / Created Date -->
                           <td class="invoice-total-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;vertical-align: top;">
-                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Total (In USD)</label>
+                            <label class="dark-grey-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #676767;">Amount reimbursed (In USD)</label>
                             <div class="total-large dark-grey-text" style="color: #676767;font-size: 29px;font-weight: 300;background-color: #f7f9fb;padding: 10px;margin: 3px 0;">
                               <%= number_to_currency(@invoice.amount_refunded) %>
                             </div>
-                            <p style="margin: 0 0 10px 0;">
-                              <time datetime="<%= l @invoice.created_at, format: '%B %e, %Y' %>">
-                                <%= l @invoice.created_at, format: '%B %e, %Y' %>
-                              </time>
-                            </p>
                           </td>
                         </tr>
                       </table>
@@ -270,17 +265,6 @@
                   <tr>
                     <td class="invoice-id-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 5px;">
                       <label class="label-black" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;">Invoice #<%= @invoice.invoice_id %></label>
-                    </td>
-                  </tr>
-                  <!-- Subscription Period -->
-                  <tr class="invoice-line">
-                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
-                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Subscription Period</label>
-                      <span>
-                        <%#= l @invoice.current_period_start, format: :long -%>
-                        &ndash;
-                        <%#= l @invoice.current_period_end, format: :long -%>
-                      </span>
                     </td>
                   </tr>
                   <!-- Status -->
@@ -297,7 +281,27 @@
                       <span><%= @invoice.plan %></span>
                     </td>
                   </tr>
-
+                  <!-- Amount paid -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
+                      <span>Amount paid <%= @invoice.amount_refunded %></span>
+                    </td>
+                  </tr>
+                  <!-- Amount paid -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
+                      <span>Amount reimbursed <%= @invoice.amount_refunded %></span>
+                    </td>
+                  </tr>
+                  <!-- Total -->
+                  <tr class="invoice-line">
+                    <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;padding-bottom: 10px;">
+                      <label class="blue-text" style="display: block;font-weight: 700;font-size: 14px;text-transform: uppercase;color: #0068ff;">Status</label>
+                      <span>Total <%= @invoice.amount_refunded %></span>
+                    </td>
+                  </tr>
                   <tr>
                     <td style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;"><hr style="border-style: solid;color: #e5e7e9;margin: 10px 0;"></td>
                   </tr>

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -94,7 +94,7 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
     let(:recipient) { 'shairyar@travis-ci.com' }
     let(:subscription) {{company: 'Ruby Monsters', first_name: 'Tessa', last_name: 'Schmidt', address: 'Rigaer Str.', city: 'Berlin', state: 'Berlin', post_code: '10000', country: 'Germany', vat_id: 'DE123456789'}}
     let(:owner) {{name: 'Ruby Monsters', login: 'rubymonsters'}}
-    let(:invoice) {{ pdf_url: pdf_url, amount_refunded: 999, amount: 999, created_at: Time.now.to_s, invoice_id: 'TP123', plan: 'Startup'}}
+    let(:invoice) {{ pdf_url: pdf_url, amount_refunded: 999, amount_paid: 999, amount: 999, created_at: Time.now.to_s, invoice_id: 'TP123', plan: 'Startup'}}
     let(:real_pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
     let(:pdf_url) { real_pdf_url }
     let(:filename) { 'TP123.pdf' }
@@ -121,7 +121,7 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
     end
 
     it 'shows the account name' do
-      expect(html).to have_text_lines('Your plan has been cancelled. We reimbursed your paid amount according to Travis CI refund policy.')
+      expect(html).to have_text_lines('Your plan has been cancelled. We reimbursed your paid amount according to the Travis CI refund policy.')
     end
 
     it 'shows who was refunded' do

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -121,12 +121,12 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
     end
 
     it 'shows the account name' do
-      expect(html).to have_text_lines('Travis CI refund for the account Ruby Monsters')
+      expect(html).to have_text_lines('Your plan has been cancelled. We reimbursed your paid amount according to Travis CI refund policy.')
     end
 
     it 'shows who was refunded' do
       expect(html).to have_text_lines(%q{
-        Billed To:
+        Issued To:
 
         Ruby Monsters
         Tessa Schmidt
@@ -139,7 +139,7 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
 
     it 'shows the total' do
       expect(html).to have_text_lines(%q{
-        Total \(In USD\)
+        Amount reimbursed \(In USD\)
         \$9.99
       })
     end

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -87,4 +87,91 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
       end
     end
   end
+
+  describe '#credit_note_raised' do
+    subject(:mail) { described_class.credit_note_raised([recipient], subscription, owner, charge, event, invoice, cc_last_digits) }
+
+    let(:recipient) { 'shairyar@travis-ci.com' }
+    let(:subscription) {{company: 'Ruby Monsters', first_name: 'Tessa', last_name: 'Schmidt', address: 'Rigaer Str.', city: 'Berlin', state: 'Berlin', post_code: '10000', country: 'Germany', vat_id: 'DE123456789'}}
+    let(:owner) {{name: 'Ruby Monsters', login: 'rubymonsters'}}
+    let(:invoice) {{ pdf_url: pdf_url, amount_refunded: 999, amount: 999, created_at: Time.now.to_s, invoice_id: 'TP123', plan: 'Startup'}}
+    let(:real_pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
+    let(:pdf_url) { real_pdf_url }
+    let(:filename) { 'TP123.pdf' }
+    let(:cc_last_digits) { '1234' }
+    let(:charge) { nil}
+    let(:event) { nil}
+
+    let(:html) { Capybara.string(mail.html_part.body.to_s) }
+
+    before do
+      stub_request(:get, real_pdf_url).to_return(status: 200, body: "% PDF", headers: {'Content-Disposition' => "attachment; filename=\"#{filename}\""})
+    end
+
+    it 'is addressed to the user' do
+      expect(mail.to).to eq([recipient])
+    end
+
+    it 'comes from Travis' do
+      expect(mail.from).to eq(['success@travis-ci.com'])
+    end
+
+    it 'has the right subject' do
+      expect(mail.subject).to eq('Travis CI: Your Payment has been refunded')
+    end
+
+    it 'shows the account name' do
+      expect(html).to have_text_lines('Travis CI refund for the account Ruby Monsters')
+    end
+
+    it 'shows who was refunded' do
+      expect(html).to have_text_lines(%q{
+        Billed To:
+
+        Ruby Monsters
+        Tessa Schmidt
+        Rigaer Str.
+        Berlin Berlin 10000
+        Germany
+        DE123456789
+      })
+    end
+
+    it 'shows the total' do
+      expect(html).to have_text_lines(%q{
+        Total \(In USD\)
+        \$9.99
+      })
+    end
+
+    it 'shows the credit card' do
+      expect(html).to have_text_lines('Paid with credit card ending in 1234')
+    end
+
+    it 'contains the PDF attached' do
+      expect(mail.attachments.size).to eq(1)
+
+      attachment = mail.attachments.first
+
+      expect(attachment.content_type).to start_with('application/pdf')
+      expect(attachment.filename).to eq(filename)
+      expect(attachment.body.raw_source).to start_with('% PDF')
+    end
+
+    context 'when the pdf url redirects' do
+      let(:pdf_url) { 'http://redirects.dev/'}
+
+      before do
+        stub_request(:get, pdf_url).to_return(status: 301, headers: { 'Location' => real_pdf_url})
+      end
+
+      it 'still attaches the pdf' do
+        expect(mail.attachments.size).to eq(1)
+
+        attachment = mail.attachments.first
+
+        expect(attachment.filename).to eq(filename)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a payment has been refunded we need to send a refund invoice and a refund email to the user this pull request takes care of it. 

![image](https://user-images.githubusercontent.com/5089055/68199034-09e05f00-ffdf-11e9-905e-156418a362fb.png)

This pull request is also associated with [this](https://github.com/travis-pro/billing-v2/issues/317) issue on billing-v2 