### PR TITLE
email wordings for refund invoice 

### DIFF
--- a/lib/travis/addons/billing/mailer/billing_mailer.rb
+++ b/lib/travis/addons/billing/mailer/billing_mailer.rb
@@ -126,6 +126,10 @@ module Travis
               @invoice.fetch(:amount_refunded) / 100.0
             end
 
+            def refund_reason
+              @invoice.fetch(:refund_reason)
+            end
+
             def created_at
               Time.parse(@invoice.fetch(:created_at))
             end

--- a/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/credit_note_raised.html.erb
@@ -212,9 +212,11 @@
                   <!-- Header - Thanks -->
                   <tr>
                     <td class="invoice-header-container" style="font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;font-size: 16px;text-align: center;">
-                      <h2 id="invoice-header" style="font-size: 30px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">We are sorry to see you go :(</h2>
+                      <% if @invoice.refund_reason != 'duplicate' %>
+                        <h2 id="invoice-header" style="font-size: 30px;font-weight: 600;margin: 1.136% 0 3.409% 0;color: #0068ff;">We are sorry to see you go :(</h2>
+                      <% end %>
                       <p style="margin: 0 0 10px 0;">
-                        Your plan has been cancelled. We reimbursed your paid amount according to the Travis CI refund policy. Attached is your refund invoice for account
+                        <% if @invoice.refund_reason != 'duplicate' %> Your plan has been cancelled. <% end %>We reimbursed your paid amount according to the Travis CI refund policy. Attached is your refund invoice for account
                         <span class="blue-text" style="color: #0068ff;"><%= @invoice.account_name %></span>.
                       </p>
                       <% unless Travis.env == "production" %>

--- a/spec/addons/billing/mailer/billing_mailer_spec.rb
+++ b/spec/addons/billing/mailer/billing_mailer_spec.rb
@@ -94,7 +94,8 @@ describe Travis::Addons::Billing::Mailer::BillingMailer do
     let(:recipient) { 'shairyar@travis-ci.com' }
     let(:subscription) {{company: 'Ruby Monsters', first_name: 'Tessa', last_name: 'Schmidt', address: 'Rigaer Str.', city: 'Berlin', state: 'Berlin', post_code: '10000', country: 'Germany', vat_id: 'DE123456789'}}
     let(:owner) {{name: 'Ruby Monsters', login: 'rubymonsters'}}
-    let(:invoice) {{ pdf_url: pdf_url, amount_refunded: 999, amount_paid: 999, amount: 999, created_at: Time.now.to_s, invoice_id: 'TP123', plan: 'Startup'}}
+    let(:refund_reason) { 'requested_by_customer' }
+    let(:invoice) {{ pdf_url: pdf_url, amount_refunded: 999, amount_paid: 999, amount: 999, created_at: Time.now.to_s, invoice_id: 'TP123', plan: 'Startup', refund_reason: refund_reason}}
     let(:real_pdf_url) {  'http://invoices.travis-ci.dev/invoices/123'}
     let(:pdf_url) { real_pdf_url }
     let(:filename) { 'TP123.pdf' }


### PR DESCRIPTION
When a refund is being made for a payment that was made in error then the email wordings will not show 

"We are sorry to see you go"

Because in this case the subscription was not cancelled only the payment was refunded.