### PR TITLE
Memoize for an hour users whose tokens failed

### DIFF
--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -37,8 +37,8 @@ module Travis
 
           def process(timeout)
             return process_vcs if repository[:vcs_type] != 'GithubRepository'.freeze
-            tokens_tried = []
-            status       = :not_ok
+            users_tried = []
+            status      = :not_ok
 
             message = %W[
               type=github_status
@@ -73,6 +73,7 @@ module Travis
               # no point in trying further
               return if details[:status].to_i == 422
 
+              users_tried << username
               error(%W[
                 type=github_status
                 build=#{build[:id]}
@@ -83,12 +84,10 @@ module Travis
                 url=#{url}
                 github_response=#{details[:status]}
                 processed_with=user_token
-                tokens_tried=#{tokens_tried}
+                users_tried=#{users_tried}
                 last_token_tried="#{token.to_s[0,3]}..."
                 rate_limit=#{rate_limit_info details[:response_headers]}
               ].join(' '))
-
-              tokens_tried << username
             end
           end
 

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -59,9 +59,10 @@ module Travis
               username, token = tokens.shift
               unless token
                 error("#{message} username=#{username} token=#{token.to_s}")
-                return
+                next
               end
 
+              # byebug
               status, details = process_with_token(username, token)
               if status == :ok
                 info("#{message} username=#{username} processed_with=user_token token=#{token[0,3]}...")

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -60,7 +60,7 @@ module Travis
 
               status, details = process_with_token(username, token)
               if status == :ok
-                info("#{message} username=:#{username} processed_with=user_token")
+                info("#{message} username=:#{username} processed_with=user_token token=#{token[0,3]}...")
                 return
               end
 
@@ -79,6 +79,7 @@ module Travis
                 github_response=#{details[:status]}
                 processed_with=user_token
                 tokens_tried=#{tokens_tried}
+                last_token_tried="#{token[0,3]}..."
                 rate_limit=#{rate_limit_info details[:response_headers]}
               ].join(' '))
 
@@ -127,6 +128,7 @@ module Travis
               reason=#{ERROR_REASONS.fetch(Integer(e.info[:response_status]))}
               processed_with=user_token
               body=#{e.info[:response_body]}
+              last_token_tried="#{token[0,3]}..."
               rate_limit=#{rate_limit_info e.info[:response_headers]}
             ].join(' '))
 
@@ -150,6 +152,7 @@ module Travis
               message=#{e.message}
               processed_with=user_token
               body=#{e.info[:response_body]}
+              last_token_tried="#{token[0,3]}..."
               rate_limit=#{rate_limit_info e.info[:response_headers]}
             ].join(' ')
             error(message)

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -68,7 +68,7 @@ module Travis
                 info("#{message} username=#{username} processed_with=user_token token=#{token[0,3]}...")
                 return
               elsif status == :skipped
-                info "Token for #{username} failed within the last hour. Skipping"
+                info "message=\"Token for #{username} failed within the last hour. Skipping\""
                 return
               end
 
@@ -92,6 +92,8 @@ module Travis
                 rate_limit=#{rate_limit_info details[:response_headers]}
               ].join(' '))
             end
+
+            error("#{message} message=\"All known tokens failed to update status\"")
           end
 
           def process_vcs
@@ -293,7 +295,7 @@ module Travis
           end
 
           def mark_user(u)
-            info "message='A request with token belonging to #{u} failed. Will skip using this token for 1 hour.'"
+            info "message=\"A request with token belonging to #{u} failed. Will skip using this token for 1 hour.\""
             redis.set errored_user_key(u), "", ex: 60*60 # an hour
           end
       end

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -57,10 +57,14 @@ module Travis
 
             while !tokens.empty? and status != :ok do
               username, token = tokens.shift
+              unless token
+                error("#{message} username=#{username} token=#{token.to_s}")
+                return
+              end
 
               status, details = process_with_token(username, token)
               if status == :ok
-                info("#{message} username=:#{username} processed_with=user_token token=#{token[0,3]}...")
+                info("#{message} username=#{username} processed_with=user_token token=#{token[0,3]}...")
                 return
               end
 
@@ -79,7 +83,7 @@ module Travis
                 github_response=#{details[:status]}
                 processed_with=user_token
                 tokens_tried=#{tokens_tried}
-                last_token_tried="#{token[0,3]}..."
+                last_token_tried="#{token.to_s[0,3]}..."
                 rate_limit=#{rate_limit_info details[:response_headers]}
               ].join(' '))
 
@@ -128,7 +132,7 @@ module Travis
               reason=#{ERROR_REASONS.fetch(Integer(e.info[:response_status]))}
               processed_with=user_token
               body=#{e.info[:response_body]}
-              last_token_tried="#{token[0,3]}..."
+              last_token_tried="#{token.to_s[0,3]}..."
               rate_limit=#{rate_limit_info e.info[:response_headers]}
             ].join(' '))
 
@@ -152,7 +156,7 @@ module Travis
               message=#{e.message}
               processed_with=user_token
               body=#{e.info[:response_body]}
-              last_token_tried="#{token[0,3]}..."
+              last_token_tried="#{token.to_s[0,3]}..."
               rate_limit=#{rate_limit_info e.info[:response_headers]}
             ].join(' ')
             error(message)

--- a/lib/travis/addons/github_status/task.rb
+++ b/lib/travis/addons/github_status/task.rb
@@ -68,7 +68,7 @@ module Travis
                 info("#{message} username=#{username} processed_with=user_token token=#{token[0,3]}...")
                 return
               elsif status == :skipped
-                info "message=\"Token for #{username} failed within the last hour. Skipping\""
+                info "#{message} message=\"Token for #{username} failed within the last hour. Skipping\""
                 return
               end
 

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -98,7 +98,7 @@ describe Travis::Addons::GithubStatus::Task do
     }.not_to raise_error
     expect(io.string).to include('response_status=404')
     expect(io.string).to include('reason=repo_not_found_or_incorrect_auth')
-    expect(io.string).to include('tokens_tried=')
+    expect(io.string).to include('users_tried=')
   end
 
   describe 'logging' do

--- a/spec/addons/github_status/task_spec.rb
+++ b/spec/addons/github_status/task_spec.rb
@@ -13,9 +13,14 @@ describe Travis::Addons::GithubStatus::Task do
   let(:gh_apps)    { stub('github_apps') }
   let(:installation_id) { '12345' }
   let(:rate_limit_data) { {"x-ratelimit-limit" => "60", "x-ratelimit-remaining" => "59", "x-ratelimit-reset" => (Time.now.to_i + 2000).to_s} }
+  let(:redis)      { Redis.new(url: Travis.config.redis.url) }
+  let(:redis_prefix) { subject.const_get("REDIS_PREFIX")}
 
   before do
     Travis.logger = Logger.new(io)
+    params.fetch(:tokens, {}).keys.each do |u|
+      redis.del(redis_prefix + "errored_users:" + u)
+    end
   end
 
   def run
@@ -80,14 +85,16 @@ describe Travis::Addons::GithubStatus::Task do
     expect(io.string).to include('reason=maximum_number_of_statuses')
   end
 
-  it 'does not raise if a 403 error was returned by GH' do
+  it 'does not raise if a 403 error was returned by GH and marks the token invalid' do
     error = { response_status: 403, response_headers: rate_limit_data }
     GH.stubs(:post).raises(GH::Error.new('failed', nil, error))
     expect {
       run
     }.not_to raise_error
+    expect(io.string).to match /A request with token belonging to svenfuchs failed\./
     expect(io.string).to include('response_status=403')
     expect(io.string).to include('reason=incorrect_auth_or_suspended_acct')
+    expect(redis.exists(redis_prefix + 'errored_users:' + 'svenfuchs')).to be true
   end
 
   it 'does not raise if a 404 error was returned by GH' do
@@ -99,6 +106,21 @@ describe Travis::Addons::GithubStatus::Task do
     expect(io.string).to include('response_status=404')
     expect(io.string).to include('reason=repo_not_found_or_incorrect_auth')
     expect(io.string).to include('users_tried=')
+  end
+
+  context "a user token has been invalidated" do
+    before :all do
+      redis.set(redis_prefix + 'errored_users:' + 'svenfuchs', "")
+    end
+
+    after :all do
+      redis.del(redis_prefix + 'errored_users:' + 'svenfuchs')
+    end
+
+    it "skips using the token" do
+      expect { run }.not_to raise_error
+      expect(io.string).to match /Token for svenfuchs failed/
+    end
   end
 
   describe 'logging' do


### PR DESCRIPTION
Instead of using the same token over and over, use Redis to remember the users whose tokens failed within one hour. This should result in additional savings in undesirable GitHub API requests.