### PR TITLE
Use connection pool to manage Redis connections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ end
 group :production do
   gem 'foreman'
 end
+
+gem "connection_pool", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -839,6 +839,7 @@ DEPENDENCIES
   actionmailer (>= 5.2.2.1)
   aws-sdk
   capybara
+  connection_pool (~> 2.2)
   faraday
   faraday_middleware
   foreman

--- a/lib/travis/support.rb
+++ b/lib/travis/support.rb
@@ -1,6 +1,7 @@
 require 'travis/logger'
 require 'travis/support/exception_handling'
 require 'travis/support/logging'
+require 'connection_pool'
 
 module Travis
   class << self
@@ -10,6 +11,10 @@ module Travis
 
     def logger=(logger)
       @logger = Logger.configure(logger, config)
+    end
+
+    def redis_pool
+      @redis_pool ||= ConnectionPool.new { Redis.new( url: Travis.config.redis.url ) }
     end
   end
 end


### PR DESCRIPTION
Reduce occurrences of `Redis::CannotConnectError`