### PR TITLE
Fix mail message about Free Plan conditions

### DIFF
--- a/lib/travis/addons/billing/mailer/views/billing_mailer/changetofree.html.erb
+++ b/lib/travis/addons/billing/mailer/views/billing_mailer/changetofree.html.erb
@@ -150,7 +150,7 @@
                   </tr>
                   <tr>
                     <td class="plan-info">
-                      You have 10,000 Credits per month.
+                      You have 10,000 Credits.
                     </td>
                   </tr>
                   <tr>
@@ -160,7 +160,7 @@
                   </tr>
                   <tr>
                     <td class="plan-info">
-                      10,000 credits will be replenished automatically monthly. Additional Credits purchase is not available for Free Tier Plan.
+                      Additional Credits purchase is not available for Free Tier Plan.
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
The mailing template contained improper information about credits being replenished monthly.