### PR TITLE
use separate domain from configs for email interpolation

### DIFF
--- a/lib/travis/addons/email/mailer/build.rb
+++ b/lib/travis/addons/email/mailer/build.rb
@@ -58,7 +58,7 @@ module Travis
             end
 
             def from_email
-              Travis.config.email.from || "notifications@#{Travis.config.host}"
+              Travis.config.email.from || "notifications@#{Travis.config.host_domain}"
             end
         end
       end

--- a/lib/travis/addons/plan/mailer/plan_mailer.rb
+++ b/lib/travis/addons/plan/mailer/plan_mailer.rb
@@ -54,7 +54,7 @@ module Travis
             end
 
             def from_email
-              config.email && config.email.plan_from || "support@#{config.host}"
+              config.email && config.email.plan_from || "support@#{config.host_domain}"
             end
 
             def reply_to
@@ -62,7 +62,7 @@ module Travis
             end
 
             def reply_to_email
-              config.email && config.email.reply_to || "support@#{config.host}"
+              config.email && config.email.reply_to || "support@#{config.host_domain}"
             end
 
             def config

--- a/lib/travis/addons/trial/mailer/trial_mailer.rb
+++ b/lib/travis/addons/trial/mailer/trial_mailer.rb
@@ -48,11 +48,11 @@ module Travis
             end
 
             def from_email
-              config.email && config.email.trials_from || "trials@#{config.host}"
+              config.email && config.email.trials_from || "trials@#{config.host_domain}"
             end
 
             def to
-              config.email && config.email.trials_to_placeholder || "trials@#{config.host}"
+              config.email && config.email.trials_to_placeholder || "trials@#{config.host_domain}"
             end
 
             def reply_to
@@ -60,7 +60,7 @@ module Travis
             end
 
             def reply_to_email
-              config.email && config.email.reply_to || "support@#{config.host}"
+              config.email && config.email.reply_to || "support@#{config.host_domain}"
             end
 
             def config

--- a/lib/travis/addons/user_confirmation/mailer/user_confirmation_mailer.rb
+++ b/lib/travis/addons/user_confirmation/mailer/user_confirmation_mailer.rb
@@ -37,11 +37,11 @@ module Travis
           end
 
           def from_email
-            config.email&.user_confirmation_from || "support@#{config.host}"
+            config.email&.user_confirmation_from || "support@#{config.host_domain}"
           end
 
           def to
-            config.email&.user_confirmation_to_placeholder || "support@#{config.host}"
+            config.email&.user_confirmation_to_placeholder || "support@#{config.host_domain}"
           end
 
           def reply_to
@@ -49,7 +49,7 @@ module Travis
           end
 
           def reply_to_email
-            config.email&.reply_to || "support@#{config.host}"
+            config.email&.reply_to || "support@#{config.host_domain}"
           end
 
           def config

--- a/lib/travis/tasks/config.rb
+++ b/lib/travis/tasks/config.rb
@@ -27,6 +27,7 @@ module Travis
       end
 
       define host:    "travis-ci.org",
+             host_domain: 'travis-ci.com',
              github:  { url: 'https://github.com' },
              redis:   { url: "redis://localhost:6379" },
              sentry:  { },

--- a/spec/addons/email/mailer/build_spec.rb
+++ b/spec/addons/email/mailer/build_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Addons::Email::Mailer::Build do
       end
 
       it 'has "notifications@[hostname]" as a from address' do
-        expect(email.from.join).to eq('notifications@travis-ci.org')
+        expect(email.from.join).to eq('notifications@travis-ci.com')
       end
     end
 

--- a/spec/addons/user_confirmation/mailer/user_confirmation_mailer_spec.rb
+++ b/spec/addons/user_confirmation/mailer/user_confirmation_mailer_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Addons::UserConfirmation::Mailer::UserConfirmationMailer do
 
     it 'contains the right data' do
       expect(mail.bcc).to eq(recipients)
-      expect(mail.from).to eq(['support@travis-ci.org'])
+      expect(mail.from).to eq(['support@travis-ci.com'])
       expect(mail.subject).to eq('Travis CI: Your account has been activated!')
       expect(mail.body).to match("Hello #{params[:owner][:name]}!")
       expect(mail.body).to match('Your account has been successfully activated.')
@@ -30,7 +30,7 @@ describe Travis::Addons::UserConfirmation::Mailer::UserConfirmationMailer do
 
     it 'contains the right data' do
       expect(mail.bcc).to eq(recipients)
-      expect(mail.from).to eq(['support@travis-ci.org'])
+      expect(mail.from).to eq(['support@travis-ci.com'])
       expect(mail.subject).to eq('Travis CI: Confirm your account.')
       expect(mail.body).to match("Hello #{params[:owner][:name]}!")
       expect(mail.body).to match('Please take a moment to confirm your account.')


### PR DESCRIPTION
use separate domain from configs for email interpolation