### PR TITLE
Send commit status to GitHub ship:docker

### DIFF
--- a/lib/travis/addons/github_check_status/task.rb
+++ b/lib/travis/addons/github_check_status/task.rb
@@ -62,7 +62,7 @@ module Travis
                 id: repository[:vcs_id],
                 type: repository[:vcs_type],
                 ref: sha,
-                payload: { "state": STATES["#{build[:state]}"], "description": DESCRIPTIONS["#{build[:state]}"] }.to_json
+                payload: { "state": STATES["#{build[:state]}"], "description": DESCRIPTIONS["#{build[:state]}"], "context": build_type }.to_json
               )
 
             rescue => e
@@ -110,6 +110,12 @@ module Travis
             end
           end
           @check_status_payload = return_data
+        end
+
+        def build_type
+          return "continuous-integration/travis-ci/#{pull_request? ? 'pr' : 'push'}" if ENV['GITHUB_STATUS_LEGACY_NAME'] == 'true'
+
+          "Travis CI - #{pull_request? ? 'Pull Request' : 'Branch'}"
         end
       end
     end


### PR DESCRIPTION
This PR sends the build [status of a commit](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) to GitHub.