### PR TITLE
Ruby gem update 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   include:
     - stage: "testing time"
+      before_install:
+        - gem install bundler:2.4.13
+        - gem install rubygems-update -v 3.4.22    
       script: bundle exec rspec -f documentation --color --order rand spec
     - stage: ":ship: it to quay.io"
       ruby:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
     - stage: ":ship: it to quay.io"
       ruby:
       before_install:
+        - gem install rubygems-update -v 3.4.22
       before_script:
       install:
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
     - stage: ":ship: it to quay.io"
       ruby:
       before_install:
+        - gem install bundler:2.4.13
         - gem install rubygems-update -v 3.4.22
       before_script:
       install:


### PR DESCRIPTION
Restrict ruby gem-update to 3.4.22 because it still supports ruby 2.6