### PR TITLE
Fix GitHub check status failing due to removed URI.escape in Ruby 3.0+

### DIFF
--- a/lib/travis/addons/github_check_status/output/helpers.rb
+++ b/lib/travis/addons/github_check_status/output/helpers.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Travis::Addons::GithubCheckStatus::Output
   module Helpers
     STATUS = {
@@ -185,7 +187,7 @@ module Travis::Addons::GithubCheckStatus::Output
     end
 
     def file_link(path)
-      path = path.split('/').map { |p| URI.escape(p) }.join('/')
+      path = path.split('/').map { |p| CGI.escape(p) }.join('/')
       Travis::Api.backend(vcs_id, vcs_type).file_url(
         id: vcs_id,
         type: vcs_type,

--- a/spec/addons/email/mailer/build_spec.rb
+++ b/spec/addons/email/mailer/build_spec.rb
@@ -15,6 +15,7 @@ describe Travis::Addons::Email::Mailer::Build do
     ActionMailer::Base.delivery_method = :test
     data['commit']['author_name'] = 'まつもとゆきひろ a.k.a. Matz'
     Travis.config.build_email_footer = true
+    Travis.config.enterprise = false
     Travis.config.emails = {}
     Travis.config.assets = {}
   end

--- a/spec/addons/github_check_status/output_spec.rb
+++ b/spec/addons/github_check_status/output_spec.rb
@@ -195,6 +195,18 @@ describe Travis::Addons::GithubCheckStatus::Output do
     example { expect(subject[:output][:text]).to eq(text) }
   end
 
+  describe 'build with gemfile in staged job' do
+    let(:payload) { TASK_PAYLOAD_WITH_GEMFILE_STAGE.deep_symbolize_keys }
+
+    example 'does not raise on gemfile matrix value' do
+      expect { subject }.not_to raise_error
+    end
+
+    example 'includes gemfile in output text' do
+      expect(subject[:output][:text]).to include('Gemfile.other')
+    end
+  end
+
   describe 'build with env data' do
     let(:payload) { TASK_PAYLOAD_WITH_ENVS.deep_symbolize_keys }
     let(:text)    { <<-MARKDOWN.gsub(/^      /, '').strip }

--- a/spec/payloads.rb
+++ b/spec/payloads.rb
@@ -177,6 +177,37 @@ TASK_PAYLOAD_WITH_STAGES = TASK_PAYLOAD.merge({
   }]
 })
 
+TASK_PAYLOAD_WITH_GEMFILE_STAGE = TASK_PAYLOAD.merge({
+  "jobs"=>[{
+    "id"=>1,
+    "number"=>"2.1",
+    "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.8.7"
+    },
+    "stage"=>{
+      "number" => 1,
+      "name"   => "Test",
+      "state"  => "passed"
+    },
+    "allow_failure"=>false
+  }, {
+    "id"=> 2,
+    "number"=>"2.2",
+    "state"=>"passed",
+    "config" => {
+      "rvm"=>"1.9.2",
+      "gemfile"=>"Gemfile.other"
+    },
+    "stage"=>{
+      "number" => 2,
+      "name"   => "Deploy",
+      "state"  => "passed"
+    },
+    "allow_failure"=>false
+  }]
+})
+
 TASK_PAYLOAD_WITH_ENVS = TASK_PAYLOAD.merge({
   "jobs"=>[{
     "id"=>1,


### PR DESCRIPTION
## Summary

- Replace removed `URI.escape` with `CGI.escape` in `file_link` helper, fixing `NoMethodError` on Ruby 3.0+ that silently kills the entire `github_check_status` Sidekiq task
- This bug is triggered when any job has a `gemfile:` matrix config key (e.g., `gemfile: Gemfile.collate`), causing `file_link` to be called during check run output generation
- Add test coverage for builds with gemfile in staged jobs
- Fix pre-existing email mailer HTML test failure caused by missing `enterprise = false` in test setup

## Context

`URI.escape` was removed in Ruby 3.0. The `file_link` method in the check status output helper still used it, causing a `NoMethodError` whenever a job includes a `gemfile:` key in its matrix config. This crashes the Sidekiq task, so no check run is ever created or updated on GitHub.